### PR TITLE
신규 강의 추가 로직 수정

### DIFF
--- a/batch/src/main/kotlin/sugangsnu/SugangSnuRepository.kt
+++ b/batch/src/main/kotlin/sugangsnu/SugangSnuRepository.kt
@@ -1,10 +1,8 @@
 package com.wafflestudio.snu4t.sugangsnu
 
-import com.wafflestudio.snu4t.common.enum.Semester
 import com.wafflestudio.snu4t.sugangsnu.api.SugangSnuApi
 import com.wafflestudio.snu4t.sugangsnu.data.SugangSnuCoursebookCondition
 import com.wafflestudio.snu4t.sugangsnu.enum.LectureCategory
-import com.wafflestudio.snu4t.sugangsnu.utils.toSugangSnuSearchString
 import org.springframework.core.io.buffer.PooledDataBuffer
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
@@ -31,8 +29,7 @@ class SugangSnuRepository(
         }.awaitExchange { it.awaitBody() }
 
     suspend fun getSugangSnuLectures(
-        year: Int,
-        semester: Semester,
+        coursebookCondition: SugangSnuCoursebookCondition,
         lectureCategory: LectureCategory = LectureCategory.NONE,
         language: String = "ko",
     ): PooledDataBuffer =
@@ -41,8 +38,8 @@ class SugangSnuRepository(
                 path(SUGANG_SNU_LECTURE_PATH)
                 query(DEFAULT_LECTURE_PARAMS)
                 queryParam("srchLanguage", language)
-                queryParam("srchOpenSchyy", year)
-                queryParam("srchOpenShtm", semester.toSugangSnuSearchString())
+                queryParam("srchOpenSchyy", coursebookCondition.latestYear)
+                queryParam("srchOpenShtm", coursebookCondition.latestSugangSnuSemester)
                 if (lectureCategory != LectureCategory.NONE) {
                     replaceQueryParam("srchOpenSbjtFldCd", lectureCategory.queryValue)
                     replaceQueryParam("srchOpenUpSbjtFldCd", lectureCategory.parentCategory)

--- a/batch/src/main/kotlin/sugangsnu/SugangSnuSyncJobConfig.kt
+++ b/batch/src/main/kotlin/sugangsnu/SugangSnuSyncJobConfig.kt
@@ -37,8 +37,7 @@ class SugangSnuSyncJobConfig {
         { _, _ ->
             runBlocking {
                 val existingCoursebook = sugangSnuSyncService.getLatestCoursebook()
-                val newLectures =
-                    sugangSnuFetchService.getLectures(existingCoursebook.year, existingCoursebook.semester)
+                val newLectures = sugangSnuFetchService.getLatestSugangSnuLectures()
                 if (sugangSnuSyncService.isSyncWithSugangSnu(existingCoursebook)) {
                     val oldLectures =
                         lectureService.getLecturesByYearAndSemesterAsFlow(

--- a/batch/src/main/kotlin/sugangsnu/data/SugangSnuCoursebookCondition.kt
+++ b/batch/src/main/kotlin/sugangsnu/data/SugangSnuCoursebookCondition.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.snu4t.sugangsnu.data
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.wafflestudio.snu4t.common.enum.Semester
 
 data class SugangSnuCoursebookCondition(
     @JsonProperty("currSchyy")
@@ -13,5 +14,13 @@ data class SugangSnuCoursebookCondition(
     val latestSugangSnuSemester: String
         get() {
             return semesterFlagPrev + semesterFlagNext
+        }
+    val latestSemester: Semester
+        get() = when (latestSugangSnuSemester) {
+            "U000200001U000300001" -> Semester.SPRING
+            "U000200001U000300002" -> Semester.SUMMER
+            "U000200002U000300001" -> Semester.AUTUMN
+            "U000200002U000300002" -> Semester.WINTER
+            else -> throw IllegalArgumentException()
         }
 }

--- a/batch/src/main/kotlin/sugangsnu/enum/LectureCategory.kt
+++ b/batch/src/main/kotlin/sugangsnu/enum/LectureCategory.kt
@@ -1,8 +1,6 @@
 package com.wafflestudio.snu4t.sugangsnu.enum
 
 enum class LectureCategory(val parentCategory: String, val queryValue: Long, val koreanName: String) {
-    NONE("", 0, ""),
-
     // 학문의 기초
     FOUNDATION_WRITING("04", 40, "사고와 표현"),
     FOUNDATION_LANGUAGE("04", 41, "외국어"),
@@ -24,5 +22,7 @@ enum class LectureCategory(val parentCategory: String, val queryValue: Long, val
     GENERAL_ART("06", 53, "예술실기"),
     GENERAL_COLLEGE("06", 54, "대학과 리더쉽"),
     GENERAL_CREATIVITY("06", 55, "창의와 융합"),
-    GENERAL_KOREAN("06", 56, "한국의 이해");
+    GENERAL_KOREAN("06", 56, "한국의 이해"),
+
+    NONE("", 0, "");
 }

--- a/batch/src/main/kotlin/sugangsnu/service/SugangSnuSyncService.kt
+++ b/batch/src/main/kotlin/sugangsnu/service/SugangSnuSyncService.kt
@@ -15,7 +15,6 @@ import com.wafflestudio.snu4t.sugangsnu.data.TimetableLectureDeleteResult
 import com.wafflestudio.snu4t.sugangsnu.data.TimetableLectureUpdateResult
 import com.wafflestudio.snu4t.sugangsnu.data.UpdatedLecture
 import com.wafflestudio.snu4t.sugangsnu.data.UserLectureSyncResult
-import com.wafflestudio.snu4t.sugangsnu.utils.toSugangSnuSearchString
 import com.wafflestudio.snu4t.tag.data.TagCollection
 import com.wafflestudio.snu4t.tag.data.TagList
 import com.wafflestudio.snu4t.tag.repository.TagListRepository
@@ -230,8 +229,7 @@ class SugangSnuSyncServiceImpl(
         }
 
     private fun Coursebook.isSyncedToSugangSnu(sugangSnuCoursebookCondition: SugangSnuCoursebookCondition): Boolean =
-        this.year == sugangSnuCoursebookCondition.latestYear &&
-            this.semester.toSugangSnuSearchString() == sugangSnuCoursebookCondition.latestSugangSnuSemester
+        this.year == sugangSnuCoursebookCondition.latestYear && this.semester == sugangSnuCoursebookCondition.latestSemester
 }
 
 data class ParsedTags(

--- a/batch/src/main/kotlin/sugangsnu/utils/SugangSnuExtensions.kt
+++ b/batch/src/main/kotlin/sugangsnu/utils/SugangSnuExtensions.kt
@@ -5,15 +5,6 @@ import com.wafflestudio.snu4t.coursebook.data.Coursebook
 import com.wafflestudio.snu4t.lectures.data.Lecture
 import kotlin.reflect.KProperty1
 
-fun Semester.toSugangSnuSearchString(): String {
-    return when (this) {
-        Semester.SPRING -> "U000200001U000300001"
-        Semester.SUMMER -> "U000200001U000300002"
-        Semester.AUTUMN -> "U000200002U000300001"
-        Semester.WINTER -> "U000200002U000300002"
-    }
-}
-
 fun KProperty1<Lecture, *>.toKoreanFieldName(): String = when (this) {
     Lecture::classification -> "교과 구분"
     Lecture::department -> "학부"


### PR DESCRIPTION
### 변경사항
- 최신 시간표 판단 이상하게 하고 있음 - sugangsnu에서 가져오도록 변경
- 존재하지 않는 카테고리가 있는 경우 엑셀 다운이 안돼 엑셀 불러오기 에러 발생 (계절학기는 이런 경우 있음) - runCatching으로 감쌈
- 전체 검색 시, 카테고리 검색 시 강의가 중복되므로 카테고리 검색 시에 강의가 전체 검색 강의를 덮어쓰도록 변경