### PR TITLE
logback 사용 및 truffle 적용

### DIFF
--- a/api/src/main/kotlin/filter/ErrorWebFilter.kt
+++ b/api/src/main/kotlin/filter/ErrorWebFilter.kt
@@ -37,7 +37,7 @@ class ErrorWebFilter(
                         )
                     }
                     else -> {
-                        logger.error(throwable.message)
+                        logger.error(throwable.message, throwable)
                         httpStatusCode = HttpStatus.INTERNAL_SERVER_ERROR
                         errorBody = makeErrorBody(Snu4tException())
                     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,17 +43,15 @@ subprojects {
         implementation("org.springframework.boot:spring-boot-starter-webflux")
         implementation("io.projectreactor.kotlin:reactor-kotlin-extensions")
         implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
-        implementation("org.springframework.boot:spring-boot-starter-log4j2")
         implementation("org.springframework.boot:spring-boot-starter-data-mongodb-reactive")
 
         implementation("org.springframework.boot:spring-boot-starter-data-redis")
 
-        implementation("com.wafflestudio.truffle.sdk:truffle-spring-boot-starter:1.0.1")
+        implementation("com.wafflestudio.truffle.sdk:truffle-spring-boot-starter:1.1.0")
+        implementation("com.wafflestudio.truffle.sdk:truffle-logback:1.1.0")
 
-        // spring docs
         implementation("org.springdoc:springdoc-openapi-starter-webflux-ui:2.0.2")
 
-        // test
         testImplementation("org.springframework.boot:spring-boot-starter-test")
         testImplementation("io.projectreactor:reactor-test")
         testImplementation("io.mockk:mockk:1.12.4")
@@ -73,14 +71,6 @@ subprojects {
 
     tasks.withType<Test> {
         useJUnitPlatform()
-    }
-
-    configurations {
-        all {
-            exclude(module = "spring-boot-starter-logging")
-            exclude(module = "logback-core")
-            exclude(module = "logback-classic")
-        }
     }
 }
 

--- a/core/src/main/resources/application-common.yml
+++ b/core/src/main/resources/application-common.yml
@@ -17,12 +17,6 @@ google:
     project-id:
     service-account:
 
-truffle:
-  client:
-    name: snutt-timetable
-    phase: local
-    api-key:
-
 secret-names: dev/snutt-timetable
 
 ---
@@ -45,8 +39,7 @@ google:
     service-account:
 
 truffle:
-  client:
-    phase: dev
+  enabled: true
 
 ---
 
@@ -67,7 +60,6 @@ google:
     service-account:
 
 truffle:
-  client:
-    phase: prod
+  enabled: true
 
 secret-names: prod/snutt-timetable

--- a/core/src/test/resources/application.yaml
+++ b/core/src/test/resources/application.yaml
@@ -9,9 +9,3 @@ logging:
     com.mongodb: ERROR
 
 de.flapdoodle.mongodb.embedded.version: 5.0.5
-
-truffle:
-  client:
-    name: snutt-timetable
-    phase: test
-    api-key: test-api-key


### PR DESCRIPTION
truffle-spring-boot-starter, truffle-logback 을 적용함으로써, handling 되지 못한 에러가 `ErrorWebFilter`에서 else 를 타며 logger.error 로 찍힐 때 Slack [#truffle-alert-snutt-backends](https://wafflestudio.slack.com/archives/C04T7UW3U8G)로 갑니다.

truffle.client.api-key 는 AWS SecretsManager 에 들어있습니다.