### PR TITLE
배치잡 강의 업데이트 시 시간 변경으로 인해 겹침 발생 시 제거

### DIFF
--- a/batch/src/main/kotlin/sugangsnu/SugangSnuRepository.kt
+++ b/batch/src/main/kotlin/sugangsnu/SugangSnuRepository.kt
@@ -25,7 +25,7 @@ class SugangSnuRepository(
     }
 
     suspend fun getCoursebookCondition(): SugangSnuCoursebookCondition =
-        sugangSnuApi.post().uri { builder ->
+        sugangSnuApi.get().uri { builder ->
             builder.path(SUGANG_SNU_COURSEBOOK_PATH)
                 .query(DEFAULT_COURSEBOOK_PARAMS)
                 .build()

--- a/batch/src/main/kotlin/sugangsnu/data/UserLectureSyncResult.kt
+++ b/batch/src/main/kotlin/sugangsnu/data/UserLectureSyncResult.kt
@@ -41,3 +41,12 @@ data class TimetableLectureDeleteResult(
     override val userId: String,
     override val lectureId: String,
 ) : UserLectureSyncResult(userId, lectureId)
+
+data class TimetableLectureDeleteByOverlapResult(
+    val year: Int,
+    val semester: Semester,
+    val timetableTitle: String,
+    val courseTitle: String,
+    override val userId: String,
+    override val lectureId: String,
+) : UserLectureSyncResult(userId, lectureId)

--- a/batch/src/main/kotlin/sugangsnu/service/SugangSnuFetchService.kt
+++ b/batch/src/main/kotlin/sugangsnu/service/SugangSnuFetchService.kt
@@ -81,8 +81,8 @@ class SugangSnuFetchServiceImpl(
         val remark = row.getCellByColumnName("비고")
 
         val periodText = SugangSnuClassTimeUtils.convertClassTimeTextToPeriodText(classTimeText)
-        val classTime = SugangSnuClassTimeUtils.convertTextToClassTimeObject(classTimeText, location)
-        val classTimeMask = ClassTimeUtils.classTimeToBitmask(classTime)
+        val classTimes = SugangSnuClassTimeUtils.convertTextToClassTimeObject(classTimeText, location)
+        val classTimeMask = ClassTimeUtils.classTimeToBitmask(classTimes)
 
         val courseFullTitle = if (courseSubtitle.isEmpty()) courseTitle else "$courseTitle ($courseSubtitle)"
 
@@ -104,7 +104,7 @@ class SugangSnuFetchServiceImpl(
             category = category.koreanName,
             classTimeText = classTimeText,
             periodText = periodText,
-            classTime = classTime,
+            classTimes = classTimes,
             classTimeMask = classTimeMask,
         )
     }

--- a/batch/src/main/kotlin/sugangsnu/service/SugangSnuNotificationService.kt
+++ b/batch/src/main/kotlin/sugangsnu/service/SugangSnuNotificationService.kt
@@ -104,7 +104,7 @@ class SugangSnuNotificationServiceImpl(
             is TimetableLectureDeleteByOverlapResult -> {
                 """
                 $year-${semester.fullName} '$timetableTitle' 시간표의 
-                '$courseTitle' 강의가 업데이트되었으나, 시간표가 겹쳐 삭제되었습니다.
+                '$courseTitle' 강의가 업데이트되었으나, 시간표의 다른 강의와 겹쳐 삭제되었습니다.
                 """.trimIndent().replace("\n", "") to NotificationType.LECTURE_REMOVE
             }
         }

--- a/batch/src/main/kotlin/sugangsnu/service/SugangSnuNotificationService.kt
+++ b/batch/src/main/kotlin/sugangsnu/service/SugangSnuNotificationService.kt
@@ -10,6 +10,7 @@ import com.wafflestudio.snu4t.notification.data.NotificationType
 import com.wafflestudio.snu4t.notification.repository.NotificationRepository
 import com.wafflestudio.snu4t.sugangsnu.data.BookmarkLectureDeleteResult
 import com.wafflestudio.snu4t.sugangsnu.data.BookmarkLectureUpdateResult
+import com.wafflestudio.snu4t.sugangsnu.data.TimetableLectureDeleteByOverlapResult
 import com.wafflestudio.snu4t.sugangsnu.data.TimetableLectureDeleteResult
 import com.wafflestudio.snu4t.sugangsnu.data.TimetableLectureUpdateResult
 import com.wafflestudio.snu4t.sugangsnu.data.UserLectureSyncResult
@@ -97,6 +98,12 @@ class SugangSnuNotificationServiceImpl(
                 """
                 $year-${semester.fullName} 관심강좌 목록의 
                 '$courseTitle' 강의가 폐강되어 삭제되었습니다.
+                """.trimIndent().replace("\n", "") to NotificationType.LECTURE_REMOVE
+            }
+            is TimetableLectureDeleteByOverlapResult -> {
+                """
+                $year-${semester.fullName} '$timetableTitle' 시간표의 
+                '$courseTitle' 강의가 업데이트되었으나, 시간표가 겹쳐 삭제되었습니다.
                 """.trimIndent().replace("\n", "") to NotificationType.LECTURE_REMOVE
             }
         }

--- a/batch/src/main/kotlin/sugangsnu/service/SugangSnuNotificationService.kt
+++ b/batch/src/main/kotlin/sugangsnu/service/SugangSnuNotificationService.kt
@@ -46,7 +46,8 @@ class SugangSnuNotificationServiceImpl(
         val userUpdatedLectureCountMap =
             syncSavedLecturesResults.filterIsInstance<TimetableLectureUpdateResult>().toCountMap()
         val userDeletedLectureCountMap =
-            syncSavedLecturesResults.filterIsInstance<TimetableLectureDeleteResult>().toCountMap()
+            syncSavedLecturesResults.filter { it is TimetableLectureDeleteResult || it is TimetableLectureDeleteByOverlapResult }
+                .toCountMap()
 
         val tokenAndMessage = (userUpdatedLectureCountMap.keys - userDeletedLectureCountMap.keys).map {
             userRepository.findById(it)?.fcmKey to "수강편람이 업데이트되어 ${userUpdatedLectureCountMap[it]}개 강의가 변경되었습니다."

--- a/batch/src/main/kotlin/sugangsnu/service/SugangSnuSyncService.kt
+++ b/batch/src/main/kotlin/sugangsnu/service/SugangSnuSyncService.kt
@@ -209,11 +209,11 @@ class SugangSnuSyncServiceImpl(
         ).let { timetables ->
             merge(
                 updateTimetableLectures(
-                    timetables.filter { isUpdatedTimetableLectureOverlapped(it, updatedLecture) },
+                    timetables.filter { !isUpdatedTimetableLectureOverlapped(it, updatedLecture) },
                     updatedLecture
                 ),
                 dropOverlappingLectures(
-                    timetables.filter { !isUpdatedTimetableLectureOverlapped(it, updatedLecture) },
+                    timetables.filter { isUpdatedTimetableLectureOverlapped(it, updatedLecture) },
                     updatedLecture
                 )
             )

--- a/batch/src/main/kotlin/sugangsnu/service/SugangSnuSyncService.kt
+++ b/batch/src/main/kotlin/sugangsnu/service/SugangSnuSyncService.kt
@@ -279,10 +279,10 @@ class SugangSnuSyncServiceImpl(
 
     fun isUpdatedTimetableLectureOverlapped(timetable: Timetable, updatedLecture: UpdatedLecture) =
         updatedLecture.updatedField.contains(Lecture::classTimes) &&
-                timetable.lectures.any {
-                    it.lectureId != updatedLecture.oldData.id &&
-                            ClassTimeUtils.timesOverlap(it.classTimes, updatedLecture.newData.classTimes)
-                }
+            timetable.lectures.any {
+                it.lectureId != updatedLecture.oldData.id &&
+                    ClassTimeUtils.timesOverlap(it.classTimes, updatedLecture.newData.classTimes)
+            }
 
     private fun deleteBookmarkLectures(deletedLecture: Lecture): Flow<BookmarkLectureDeleteResult> =
         bookmarkRepository.findAllContainsLectureId(

--- a/batch/src/main/kotlin/sugangsnu/service/SugangSnuSyncService.kt
+++ b/batch/src/main/kotlin/sugangsnu/service/SugangSnuSyncService.kt
@@ -6,11 +6,13 @@ import com.wafflestudio.snu4t.coursebook.data.Coursebook
 import com.wafflestudio.snu4t.coursebook.repository.CoursebookRepository
 import com.wafflestudio.snu4t.lectures.data.Lecture
 import com.wafflestudio.snu4t.lectures.service.LectureService
+import com.wafflestudio.snu4t.lectures.utils.ClassTimeUtils
 import com.wafflestudio.snu4t.sugangsnu.SugangSnuRepository
 import com.wafflestudio.snu4t.sugangsnu.data.BookmarkLectureDeleteResult
 import com.wafflestudio.snu4t.sugangsnu.data.BookmarkLectureUpdateResult
 import com.wafflestudio.snu4t.sugangsnu.data.SugangSnuCoursebookCondition
 import com.wafflestudio.snu4t.sugangsnu.data.SugangSnuLectureCompareResult
+import com.wafflestudio.snu4t.sugangsnu.data.TimetableLectureDeleteByOverlapResult
 import com.wafflestudio.snu4t.sugangsnu.data.TimetableLectureDeleteResult
 import com.wafflestudio.snu4t.sugangsnu.data.TimetableLectureUpdateResult
 import com.wafflestudio.snu4t.sugangsnu.data.UpdatedLecture
@@ -18,8 +20,10 @@ import com.wafflestudio.snu4t.sugangsnu.data.UserLectureSyncResult
 import com.wafflestudio.snu4t.tag.data.TagCollection
 import com.wafflestudio.snu4t.tag.data.TagList
 import com.wafflestudio.snu4t.tag.repository.TagListRepository
+import com.wafflestudio.snu4t.timetables.data.Timetable
 import com.wafflestudio.snu4t.timetables.repository.TimetableRepository
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.toList
@@ -148,7 +152,7 @@ class SugangSnuSyncServiceImpl(
 
     private fun syncTimetableLectures(compareResult: SugangSnuLectureCompareResult) =
         merge(
-            compareResult.updatedLectureList.map { updateTimetableLectures(it) }.merge(),
+            compareResult.updatedLectureList.map { checkOverlapAndUpdateTimetableLectures(it) }.merge(),
             compareResult.deletedLectureList.map { deleteTimetableLectures(it) }.merge(),
         )
 
@@ -165,25 +169,23 @@ class SugangSnuSyncServiceImpl(
             updatedLecture.oldData.id!!
         ).map { bookmark ->
             bookmark.apply {
-                lectures = lectures.map { lecture ->
-                    if (lecture.id == updatedLecture.oldData.id) lecture.apply {
-                        academicYear = updatedLecture.newData.academicYear
-                        category = updatedLecture.newData.category
-                        periodText = updatedLecture.newData.periodText
-                        classTimeText = updatedLecture.newData.classTimeText
-                        classTime = updatedLecture.newData.classTime
-                        classTimeMask = updatedLecture.newData.classTimeMask
-                        classification = updatedLecture.newData.classification
-                        credit = updatedLecture.newData.credit
-                        department = updatedLecture.newData.department
-                        instructor = updatedLecture.newData.instructor
-                        quota = updatedLecture.newData.quota
-                        freshmanQuota = updatedLecture.newData.freshmanQuota
-                        remark = updatedLecture.newData.remark
-                        lectureNumber = updatedLecture.newData.lectureNumber
-                        courseNumber = updatedLecture.newData.courseNumber
-                        courseTitle = updatedLecture.newData.courseTitle
-                    } else lecture
+                lectures.find { it.id == updatedLecture.oldData.id }?.apply {
+                    academicYear = updatedLecture.newData.academicYear
+                    category = updatedLecture.newData.category
+                    periodText = updatedLecture.newData.periodText
+                    classTimeText = updatedLecture.newData.classTimeText
+                    classTimes = updatedLecture.newData.classTimes
+                    classTimeMask = updatedLecture.newData.classTimeMask
+                    classification = updatedLecture.newData.classification
+                    credit = updatedLecture.newData.credit
+                    department = updatedLecture.newData.department
+                    instructor = updatedLecture.newData.instructor
+                    quota = updatedLecture.newData.quota
+                    freshmanQuota = updatedLecture.newData.freshmanQuota
+                    remark = updatedLecture.newData.remark
+                    lectureNumber = updatedLecture.newData.lectureNumber
+                    courseNumber = updatedLecture.newData.courseNumber
+                    courseTitle = updatedLecture.newData.courseTitle
                 }
             }
         }.let {
@@ -199,32 +201,47 @@ class SugangSnuSyncServiceImpl(
             )
         }
 
-    private fun updateTimetableLectures(updatedLecture: UpdatedLecture): Flow<TimetableLectureUpdateResult> =
+    private fun checkOverlapAndUpdateTimetableLectures(updatedLecture: UpdatedLecture): Flow<UserLectureSyncResult> =
         timeTableRepository.findAllContainsLectureId(
             updatedLecture.oldData.year,
             updatedLecture.oldData.semester,
             updatedLecture.oldData.id!!
-        ).map { timetable ->
+        ).let { timetables ->
+            merge(
+                updateTimetableLectures(
+                    timetables.filter { isUpdatedTimetableLectureOverlapped(it, updatedLecture) },
+                    updatedLecture
+                ),
+                dropOverlappingLectures(
+                    timetables.filter { !isUpdatedTimetableLectureOverlapped(it, updatedLecture) },
+                    updatedLecture
+                )
+            )
+        }
+
+    private fun updateTimetableLectures(
+        timetables: Flow<Timetable>,
+        updatedLecture: UpdatedLecture
+    ): Flow<TimetableLectureUpdateResult> =
+        timetables.map { timetable ->
             timetable.apply {
-                lectures = lectures.map { lecture ->
-                    if (lecture.lectureId == updatedLecture.oldData.id) lecture.apply {
-                        academicYear = updatedLecture.newData.academicYear
-                        category = updatedLecture.newData.category
-                        periodText = updatedLecture.newData.periodText
-                        classTimeText = updatedLecture.newData.classTimeText
-                        classTime = updatedLecture.newData.classTime
-                        classTimeMask = updatedLecture.newData.classTimeMask
-                        classification = updatedLecture.newData.classification
-                        credit = updatedLecture.newData.credit
-                        department = updatedLecture.newData.department
-                        instructor = updatedLecture.newData.instructor
-                        lectureNumber = updatedLecture.newData.lectureNumber
-                        quota = updatedLecture.newData.quota
-                        freshmanQuota = updatedLecture.newData.freshmanQuota
-                        remark = updatedLecture.newData.remark
-                        courseNumber = updatedLecture.newData.courseNumber
-                        courseTitle = updatedLecture.newData.courseTitle
-                    } else lecture
+                lectures.find { it.lectureId == updatedLecture.oldData.id }?.apply {
+                    academicYear = updatedLecture.newData.academicYear
+                    category = updatedLecture.newData.category
+                    periodText = updatedLecture.newData.periodText
+                    classTimeText = updatedLecture.newData.classTimeText
+                    classTimes = updatedLecture.newData.classTimes
+                    classTimeMask = updatedLecture.newData.classTimeMask
+                    classification = updatedLecture.newData.classification
+                    credit = updatedLecture.newData.credit
+                    department = updatedLecture.newData.department
+                    instructor = updatedLecture.newData.instructor
+                    lectureNumber = updatedLecture.newData.lectureNumber
+                    quota = updatedLecture.newData.quota
+                    freshmanQuota = updatedLecture.newData.freshmanQuota
+                    remark = updatedLecture.newData.remark
+                    courseNumber = updatedLecture.newData.courseNumber
+                    courseTitle = updatedLecture.newData.courseTitle
                 }
                 updatedAt = Instant.now()
             }
@@ -241,6 +258,31 @@ class SugangSnuSyncServiceImpl(
                 updatedFields = updatedLecture.updatedField
             )
         }
+
+    fun dropOverlappingLectures(
+        timetables: Flow<Timetable>,
+        updatedLecture: UpdatedLecture
+    ) = timetables.map { it.apply { lectures.dropWhile { lecture -> lecture.lectureId == updatedLecture.oldData.id } } }
+        .let {
+            timeTableRepository.saveAll(it)
+        }
+        .map { timetable ->
+            TimetableLectureDeleteByOverlapResult(
+                year = timetable.year,
+                semester = timetable.semester,
+                lectureId = updatedLecture.oldData.id!!,
+                userId = timetable.userId,
+                timetableTitle = timetable.title,
+                courseTitle = updatedLecture.oldData.courseTitle,
+            )
+        }
+
+    fun isUpdatedTimetableLectureOverlapped(timetable: Timetable, updatedLecture: UpdatedLecture) =
+        updatedLecture.updatedField.contains(Lecture::classTimes) &&
+                timetable.lectures.any {
+                    it.lectureId != updatedLecture.oldData.id &&
+                            ClassTimeUtils.timesOverlap(it.classTimes, updatedLecture.newData.classTimes)
+                }
 
     private fun deleteBookmarkLectures(deletedLecture: Lecture): Flow<BookmarkLectureDeleteResult> =
         bookmarkRepository.findAllContainsLectureId(

--- a/batch/src/main/kotlin/sugangsnu/utils/SugangSnuExtensions.kt
+++ b/batch/src/main/kotlin/sugangsnu/utils/SugangSnuExtensions.kt
@@ -24,7 +24,7 @@ fun KProperty1<Lecture, *>.toKoreanFieldName(): String = when (this) {
     Lecture::quota -> "정원"
     Lecture::remark -> "비고"
     Lecture::category -> "교양 구분"
-    Lecture::classTime -> "강의 시간/장소"
+    Lecture::classTimes -> "강의 시간/장소"
     else -> "기타"
 }
 

--- a/core/src/main/kotlin/lectures/data/BookmarkLecture.kt
+++ b/core/src/main/kotlin/lectures/data/BookmarkLecture.kt
@@ -22,7 +22,7 @@ data class BookmarkLecture(
     var classTimeText: String?,
     @Field("class_time_json")
     @JsonProperty("class_time_json")
-    var classTime: List<ClassTime>,
+    var classTimes: List<ClassTime>,
     @Field("class_time_mask")
     var classTimeMask: List<Int>,
     var classification: String?,
@@ -46,7 +46,7 @@ fun BookmarkLecture(lecture: Lecture): BookmarkLecture = BookmarkLecture(
     category = lecture.category,
     periodText = lecture.periodText,
     classTimeText = lecture.classTimeText,
-    classTime = lecture.classTime,
+    classTimes = lecture.classTimes,
     classTimeMask = lecture.classTimeMask,
     classification = lecture.classification,
     credit = lecture.credit,

--- a/core/src/main/kotlin/lectures/data/Lecture.kt
+++ b/core/src/main/kotlin/lectures/data/Lecture.kt
@@ -19,7 +19,7 @@ data class Lecture(
     @Field("real_class_time")
     var classTimeText: String?,
     @Field("class_time_json")
-    var classTime: List<ClassTime>,
+    var classTimes: List<ClassTime>,
     @Field("class_time_mask")
     var classTimeMask: List<Int>,
     var classification: String?,

--- a/core/src/main/kotlin/lectures/service/LectureFixture.kt
+++ b/core/src/main/kotlin/lectures/service/LectureFixture.kt
@@ -16,7 +16,7 @@ class LectureFixture(private val lectureRepository: LectureRepository) {
                 category = "",
                 periodText = "",
                 classTimeText = "",
-                classTime = listOf(),
+                classTimes = listOf(),
                 classTimeMask = listOf(),
                 classification = "",
                 credit = 1,

--- a/core/src/main/kotlin/lectures/utils/ClassTimeUtils.kt
+++ b/core/src/main/kotlin/lectures/utils/ClassTimeUtils.kt
@@ -19,4 +19,23 @@ object ClassTimeUtils {
 
         return bitTable.map { day -> day.reduce { res, i -> res.shl(1) + i } }
     }
+
+    fun parseMinute(classTime: String) =
+        classTime.split(":").let { (hour, minute) -> hour.toInt() * 60 + minute.toInt() }
+
+    fun timesOverlap(times1: List<ClassTime>, times2: List<ClassTime>) =
+        times1.any { classTime1 ->
+            times2.any { classTime2 ->
+                twoTimesOverlap( classTime1, classTime2 )
+            }
+        }
+
+    fun twoTimesOverlap(time1: ClassTime, time2: ClassTime) =
+        time1.day == time2.day &&
+                time1.startTimeMinute < time2.endTimeMinute && time1.endTimeMinute > time2.startTimeMinute
 }
+
+val ClassTime.startTimeMinute: Int
+    get() = ClassTimeUtils.parseMinute(startTime)
+val ClassTime.endTimeMinute: Int
+    get() = ClassTimeUtils.parseMinute(endTime)

--- a/core/src/main/kotlin/lectures/utils/ClassTimeUtils.kt
+++ b/core/src/main/kotlin/lectures/utils/ClassTimeUtils.kt
@@ -26,13 +26,13 @@ object ClassTimeUtils {
     fun timesOverlap(times1: List<ClassTime>, times2: List<ClassTime>) =
         times1.any { classTime1 ->
             times2.any { classTime2 ->
-                twoTimesOverlap( classTime1, classTime2 )
+                twoTimesOverlap(classTime1, classTime2)
             }
         }
 
     fun twoTimesOverlap(time1: ClassTime, time2: ClassTime) =
         time1.day == time2.day &&
-                time1.startTimeMinute < time2.endTimeMinute && time1.endTimeMinute > time2.startTimeMinute
+            time1.startTimeMinute < time2.endTimeMinute && time1.endTimeMinute > time2.startTimeMinute
 }
 
 val ClassTime.startTimeMinute: Int

--- a/core/src/main/kotlin/timetables/data/TimetableLecture.kt
+++ b/core/src/main/kotlin/timetables/data/TimetableLecture.kt
@@ -25,7 +25,7 @@ data class TimetableLecture(
     var classTimeText: String?,
     @Field("class_time_json")
     @JsonProperty("class_time_json")
-    var classTime: List<ClassTime>,
+    var classTimes: List<ClassTime>,
     @Field("class_time_mask")
     var classTimeMask: List<Int>,
     var classification: String?,


### PR DESCRIPTION
~급하게 작업했는데~
~수강스누 점검해서 테스트는 못해봄~

테스트 완료
<img width="287" alt="image" src="https://user-images.githubusercontent.com/48513130/234470663-60fd952a-0d7a-44ea-a8c2-9a6bc1d6a6d8.png">


강의 시간 변경 시 겹치는 경우 `~~~ 강의가 업데이트되었으나, 시간표가 겹쳐 삭제되었습니다.`

원래 구현이랑 똑같이 구현했고
우연히 두 강의 시간이 자리를 바꿔서 제대로 자리잡는 경우 < 이런 케이스 대응하려다가 일단 관뒀어요ㅋㅋ
현재는 기존 시간표와 바뀐 강의가 겹치면 무조건 삭제되는 스펙