### PR TITLE
[#79] 시간대 검색 수정

### DIFF
--- a/core/src/main/kotlin/common/enum/DayOfWeek.kt
+++ b/core/src/main/kotlin/common/enum/DayOfWeek.kt
@@ -1,7 +1,6 @@
 package com.wafflestudio.snu4t.common.enum
 
 import com.fasterxml.jackson.annotation.JsonValue
-import com.wafflestudio.snu4t.common.exception.Snu4tException
 import org.springframework.core.convert.converter.Converter
 import org.springframework.data.convert.ReadingConverter
 import org.springframework.data.convert.WritingConverter

--- a/core/src/main/kotlin/common/enum/DayOfWeek.kt
+++ b/core/src/main/kotlin/common/enum/DayOfWeek.kt
@@ -32,15 +32,8 @@ enum class DayOfWeek(
 
 @ReadingConverter
 @Component
-class DayOfWeekReadConverter : Converter<Any, DayOfWeek> {
-    override fun convert(source: Any): DayOfWeek {
-        return when (source) {
-            is Int -> DayOfWeek.getOfValue(source)!!
-            // TODO: node 서버 이전 이후에 전부 Int 타입으로 바꾸고 아래 double type 삭제하면 좋을 듯
-            is Double -> DayOfWeek.getOfValue(source)!!
-            else -> throw Snu4tException()
-        }
-    }
+class DayOfWeekReadConverter : Converter<Int, DayOfWeek> {
+    override fun convert(source: Int): DayOfWeek = DayOfWeek.getOfValue(source)!!
 }
 
 @Component


### PR DESCRIPTION
- 배치 옮기면서 day 값 int로 migration 끝나서 converter 바꿈
- 분 timemask로 변경 오동작
- 몽고 쿼리 오류 -> elemMatch이용하도록 변경 ( all은 원하는대로 동작하지 않았음 - 애초에 all에는 criteria가 들어갈 수 없었음  )
  - 기존 원하던 로직: 수업의 모든 수업시간이 제시된 시간 중 하나에 포함된다.
  - 변경 로직: 수업의 수업시간 중 하나라도 제시된 시간 모두와 맞지 않는다면 제외한다.