### PR TITLE
[hotfix] 업데이트된 강의 찾는 로직 반대로 들어가는 버그 수정

### DIFF
--- a/batch/src/main/kotlin/sugangsnu/job/sync/service/SugangSnuSyncService.kt
+++ b/batch/src/main/kotlin/sugangsnu/job/sync/service/SugangSnuSyncService.kt
@@ -89,7 +89,7 @@ class SugangSnuSyncServiceImpl(
         val created = (newMap.keys - oldMap.keys).map(newMap::getValue)
         val updated = (newMap.keys intersect oldMap.keys)
             .map { oldMap[it]!! to newMap[it]!! }
-            .filter { (old, new) -> old equalsMetadata new }
+            .filter { (old, new) -> !(old equalsMetadata new) }
             .map { (old, new) ->
                 UpdatedLecture(
                     old, new,


### PR DESCRIPTION
https://github.com/wafflestudio/snutt-timetable/commit/6ddc3990ae2f8d6a1e8ba86351793405e42eb9be
여기서 로직 아예 반대로 수정해버림