### PR TITLE
회원가입의 redis lock 로직 수정

### DIFF
--- a/core/src/main/kotlin/common/cache/CacheRepository.kt
+++ b/core/src/main/kotlin/common/cache/CacheRepository.kt
@@ -1,11 +1,14 @@
 package com.wafflestudio.snu4t.common.cache
 
 import kotlinx.coroutines.reactive.awaitSingle
+import org.slf4j.LoggerFactory
 import org.springframework.data.redis.core.ReactiveStringRedisTemplate
 import org.springframework.stereotype.Repository
 
 interface CacheRepository {
     suspend fun acquireLock(builtKey: BuiltCacheKey): Boolean
+
+    suspend fun releaseLock(builtKey: BuiltCacheKey): Boolean
 
     suspend fun flushDatabase()
 }
@@ -14,8 +17,16 @@ interface CacheRepository {
 class RedisCacheRepository(
     private val reactiveRedisTemplate: ReactiveStringRedisTemplate
 ) : CacheRepository {
+    private val log = LoggerFactory.getLogger(javaClass)
+
     override suspend fun acquireLock(builtKey: BuiltCacheKey): Boolean {
+        log.debug("[CACHE SETNX] {}", builtKey.key)
         return reactiveRedisTemplate.opsForValue().setIfAbsent(builtKey.key, "true", builtKey.ttl).awaitSingle()
+    }
+
+    override suspend fun releaseLock(builtKey: BuiltCacheKey): Boolean {
+        log.debug("[CACHE DEL] {}", builtKey.key)
+        return reactiveRedisTemplate.delete(builtKey.key).awaitSingle() > 0
     }
 
     override suspend fun flushDatabase() {


### PR DESCRIPTION
https://wafflestudio.slack.com/archives/C0PAVPS5T/p1684749829145739

비즈니스 로직 에러의 경우 lock 을 제거하여 유저가 재시도했을 때 중복 에러라고 하지 않도록 함.