### PR TITLE
[Naming Convention] logger -> log

### DIFF
--- a/api/src/main/kotlin/filter/ErrorWebFilter.kt
+++ b/api/src/main/kotlin/filter/ErrorWebFilter.kt
@@ -18,7 +18,7 @@ import reactor.core.publisher.Mono
 class ErrorWebFilter(
     private val objectMapper: ObjectMapper,
 ) : WebFilter {
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val log = LoggerFactory.getLogger(javaClass)
 
     override fun filter(exchange: ServerWebExchange, chain: WebFilterChain): Mono<Void> {
         return chain.filter(exchange)
@@ -37,7 +37,7 @@ class ErrorWebFilter(
                         )
                     }
                     else -> {
-                        logger.error(throwable.message, throwable)
+                        log.error(throwable.message, throwable)
                         httpStatusCode = HttpStatus.INTERNAL_SERVER_ERROR
                         errorBody = makeErrorBody(Snu4tException())
                     }

--- a/batch/src/main/kotlin/sugangsnu/common/service/SugangSnuFetchService.kt
+++ b/batch/src/main/kotlin/sugangsnu/common/service/SugangSnuFetchService.kt
@@ -18,7 +18,7 @@ interface SugangSnuFetchService {
 class SugangSnuFetchServiceImpl(
     private val sugangSnuRepository: SugangSnuRepository,
 ) : SugangSnuFetchService {
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val log = LoggerFactory.getLogger(javaClass)
     private val quotaRegex = """(?<quota>\d+)(\s*\((?<quotaForCurrentStudent>\d+)\))?""".toRegex()
 
     override suspend fun getSugangSnuLectures(year: Int, semester: Semester): List<Lecture> =
@@ -56,7 +56,7 @@ class SugangSnuFetchServiceImpl(
             this[
                 columnNameIndex.getOrElse(key) {
                     // TODO: slack 메시지로 보내기
-                    logger.error("$key 와 매칭되는 excel 컬럼이 존재하지 않습니다.")
+                    log.error("$key 와 매칭되는 excel 컬럼이 존재하지 않습니다.")
                     this.size
                 }
             ].stringCellValue

--- a/batch/src/main/kotlin/sugangsnu/common/utils/SugangSnuClassTimeUtils.kt
+++ b/batch/src/main/kotlin/sugangsnu/common/utils/SugangSnuClassTimeUtils.kt
@@ -7,7 +7,7 @@ import org.slf4j.LoggerFactory
 import java.text.DecimalFormat
 
 object SugangSnuClassTimeUtils {
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val log = LoggerFactory.getLogger(javaClass)
     private val classTimeRegEx =
         """^(?<day>[월화수목금토일])\((?<startHour>\d{2}):(?<startMinute>\d{2})~(?<endHour>\d{2}):(?<endMinute>\d{2})\)$""".toRegex()
     private val periodFormat = DecimalFormat("#.#")
@@ -35,7 +35,7 @@ object SugangSnuClassTimeUtils {
             }
             .sortedWith(compareBy({ it.day.value }, { it.startMinute }))
     }.getOrElse {
-        logger.error("classtime으로 변환 실패 (time: {}, location: {})", classTimesText, locationsText)
+        log.error("classtime으로 변환 실패 (time: {}, location: {})", classTimesText, locationsText)
         emptyList()
     }
 

--- a/batch/src/main/kotlin/sugangsnu/job/vacancynotification/service/VacancyNotifierService.kt
+++ b/batch/src/main/kotlin/sugangsnu/job/vacancynotification/service/VacancyNotifierService.kt
@@ -39,15 +39,15 @@ class VacancyNotifierServiceImpl(
         private const val DELAY_PER_CHUNK = 300L
     }
 
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val log = LoggerFactory.getLogger(javaClass)
     private val courseNumberRegex = """(?<courseNumber>.*)\((?<lectureNumber>\d+)\)""".toRegex()
 
     override suspend fun noti(coursebook: Coursebook): VacancyNotificationJobResult {
-        logger.info("시작")
+        log.info("시작")
         val registrationStatus = runCatching {
             getRegistrationStatus()
         }.getOrElse {
-            logger.error("부하기간")
+            log.error("부하기간")
             return VacancyNotificationJobResult.OVERLOAD_PERIOD
         }
         if (registrationStatus.all { it.registrationCount == 0 }) return VacancyNotificationJobResult.REGISTRATION_IS_NOT_STARTED
@@ -82,7 +82,7 @@ class VacancyNotifierServiceImpl(
         lectureService.upsertLectures(updated)
 
         notiTargetLectures.forEach {
-            logger.info("이름: ${it.courseTitle}, 강좌번호: ${it.courseNumber}, 분반번호: ${it.lectureNumber}")
+            log.info("이름: ${it.courseTitle}, 강좌번호: ${it.courseNumber}, 분반번호: ${it.lectureNumber}")
         }
 
         supervisorScope {

--- a/core/src/main/kotlin/common/dynamiclink/client/DynamicLinkClient.kt
+++ b/core/src/main/kotlin/common/dynamiclink/client/DynamicLinkClient.kt
@@ -27,8 +27,7 @@ class FirebaseDynamicLinkClient(
     @Value("\${google.firebase.dynamic-link.ios.bundle-id}") val iosBundleId: String,
     @Value("\${google.firebase.dynamic-link.ios.app-store-id:#{null}}") val iosAppStoreId: String?,
 ) : DynamicLinkClient {
-
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val log = LoggerFactory.getLogger(javaClass)
 
     companion object {
         const val SHORT_LINK_PATH = "shortLinks"
@@ -47,7 +46,7 @@ class FirebaseDynamicLinkClient(
             .retrieve()
             .awaitBody<DynamicLinkResponse>()
     }.getOrElse {
-        logger.error("링크 생성 실패 (payload: {}, error: {}", dynamicLinkRequest, it.message)
+        log.error("링크 생성 실패 (payload: {}, error: {}", dynamicLinkRequest, it.message)
         throw DynamicLinkGenerationFailedException
     }
 


### PR DESCRIPTION
`logger`, `log` 혼용해서 쓰이고 있던 것을 `log`로 통일.

근거는 lombok 의 `@Slf4j` annotation 달면 `log`라는 변수명이 사용되므로 여기서 레퍼런스함.

https://github.com/wafflestudio/snutt-timetable/issues/70#issuecomment-1605311226 여기에도 아까 적어둠.