### PR TITLE
modify notification logic

### DIFF
--- a/batch/src/main/kotlin/sugangsnu/common/service/SugangSnuNotificationService.kt
+++ b/batch/src/main/kotlin/sugangsnu/common/service/SugangSnuNotificationService.kt
@@ -8,9 +8,11 @@ import com.wafflestudio.snu4t.notification.data.NotificationType
 import com.wafflestudio.snu4t.notification.service.NotificationService
 import com.wafflestudio.snu4t.sugangsnu.common.utils.toKoreanFieldName
 import com.wafflestudio.snu4t.sugangsnu.job.sync.data.BookmarkLectureDeleteResult
+import com.wafflestudio.snu4t.sugangsnu.job.sync.data.BookmarkLectureSyncResult
 import com.wafflestudio.snu4t.sugangsnu.job.sync.data.BookmarkLectureUpdateResult
 import com.wafflestudio.snu4t.sugangsnu.job.sync.data.TimetableLectureDeleteByOverlapResult
 import com.wafflestudio.snu4t.sugangsnu.job.sync.data.TimetableLectureDeleteResult
+import com.wafflestudio.snu4t.sugangsnu.job.sync.data.TimetableLectureSyncResult
 import com.wafflestudio.snu4t.sugangsnu.job.sync.data.TimetableLectureUpdateResult
 import com.wafflestudio.snu4t.sugangsnu.job.sync.data.UserLectureSyncResult
 import kotlinx.coroutines.launch
@@ -68,13 +70,24 @@ class SugangSnuNotificationServiceImpl(
             val userId = syncResult.userId
             val (detailMessage, notificationType) = syncResult.toDetailMessageAndNotificationType()
 
-            userId to PushMessage(
-                title = "수강편람 업데이트",
-                body = userIdToMessageBody[userId]!!,
-                type = notificationType,
-                urlScheme = notificationScheme,
-                detailMessage = detailMessage,
-            )
+            userId to when (syncResult) {
+                is TimetableLectureSyncResult -> PushMessage(
+                    title = "수강편람 업데이트",
+                    body = userIdToMessageBody[userId]!!,
+                    type = notificationType,
+                    urlScheme = notificationScheme,
+                    detailMessage = detailMessage,
+                    notify = true,
+                )
+                is BookmarkLectureSyncResult -> PushMessage(
+                    title = "수강편람 업데이트",
+                    body = detailMessage,
+                    type = notificationType,
+                    urlScheme = notificationScheme,
+                    detailMessage = detailMessage,
+                    notify = false,
+                )
+            }
         }
     }
 

--- a/batch/src/main/kotlin/sugangsnu/job/sync/data/UserLectureSyncResult.kt
+++ b/batch/src/main/kotlin/sugangsnu/job/sync/data/UserLectureSyncResult.kt
@@ -6,6 +6,16 @@ import kotlin.reflect.KProperty1
 
 sealed class UserLectureSyncResult(open val userId: String, open val lectureId: String)
 
+sealed class BookmarkLectureSyncResult(
+    override val userId: String,
+    override val lectureId: String,
+) : UserLectureSyncResult(userId, lectureId)
+
+sealed class TimetableLectureSyncResult(
+    override val userId: String,
+    override val lectureId: String,
+) : UserLectureSyncResult(userId, lectureId)
+
 data class BookmarkLectureUpdateResult(
     val year: Int,
     val semester: Semester,
@@ -13,7 +23,7 @@ data class BookmarkLectureUpdateResult(
     override val userId: String,
     override val lectureId: String,
     val updatedFields: List<KProperty1<Lecture, *>>,
-) : UserLectureSyncResult(userId, lectureId)
+) : BookmarkLectureSyncResult(userId, lectureId)
 
 data class BookmarkLectureDeleteResult(
     val year: Int,
@@ -21,7 +31,7 @@ data class BookmarkLectureDeleteResult(
     val courseTitle: String,
     override val userId: String,
     override val lectureId: String,
-) : UserLectureSyncResult(userId, lectureId)
+) : BookmarkLectureSyncResult(userId, lectureId)
 
 data class TimetableLectureUpdateResult(
     val year: Int,
@@ -31,7 +41,7 @@ data class TimetableLectureUpdateResult(
     override val userId: String,
     override val lectureId: String,
     val updatedFields: List<KProperty1<Lecture, *>>,
-) : UserLectureSyncResult(userId, lectureId)
+) : TimetableLectureSyncResult(userId, lectureId)
 
 data class TimetableLectureDeleteResult(
     val year: Int,
@@ -40,7 +50,7 @@ data class TimetableLectureDeleteResult(
     val courseTitle: String,
     override val userId: String,
     override val lectureId: String,
-) : UserLectureSyncResult(userId, lectureId)
+) : TimetableLectureSyncResult(userId, lectureId)
 
 data class TimetableLectureDeleteByOverlapResult(
     val year: Int,
@@ -49,4 +59,4 @@ data class TimetableLectureDeleteByOverlapResult(
     val courseTitle: String,
     override val userId: String,
     override val lectureId: String,
-) : UserLectureSyncResult(userId, lectureId)
+) : TimetableLectureSyncResult(userId, lectureId)

--- a/batch/src/main/kotlin/sugangsnu/job/vacancynotification/service/VacancyNotifierService.kt
+++ b/batch/src/main/kotlin/sugangsnu/job/vacancynotification/service/VacancyNotifierService.kt
@@ -5,7 +5,7 @@ import com.wafflestudio.snu4t.common.push.dto.PushMessage
 import com.wafflestudio.snu4t.coursebook.data.Coursebook
 import com.wafflestudio.snu4t.lectures.service.LectureService
 import com.wafflestudio.snu4t.notification.data.NotificationType
-import com.wafflestudio.snu4t.notification.service.NotificationService
+import com.wafflestudio.snu4t.notification.service.PushNotificationService
 import com.wafflestudio.snu4t.sugangsnu.common.SugangSnuRepository
 import com.wafflestudio.snu4t.sugangsnu.job.vacancynotification.data.RegistrationStatus
 import com.wafflestudio.snu4t.sugangsnu.job.vacancynotification.data.VacancyNotificationJobResult
@@ -30,7 +30,7 @@ interface VacancyNotifierService {
 @Service
 class VacancyNotifierServiceImpl(
     private val lectureService: LectureService,
-    private val notificationService: NotificationService,
+    private val pushNotificationService: PushNotificationService,
     private val vacancyNotificationRepository: VacancyNotificationRepository,
     private val sugangSnuRepository: SugangSnuRepository,
 ) : VacancyNotifierService {
@@ -89,8 +89,8 @@ class VacancyNotifierServiceImpl(
             notiTargetLectures.forEach { lecture ->
                 launch {
                     val userIds = vacancyNotificationRepository.findAllByLectureId(lecture.id!!).map { it.userId }.toList()
-                    val pushMessage = PushMessage(lecture.courseTitle, "자리났다", NotificationType.NORMAL)
-                    notificationService.sendPushes(userIds, pushMessage)
+                    val pushMessage = PushMessage(title = lecture.courseTitle, body = "자리났다")
+                    pushNotificationService.sendPushesAndNotifications(pushMessage, NotificationType.NORMAL, userIds)
                 }
             }
         }

--- a/core/src/main/kotlin/common/push/dto/PushMessages.kt
+++ b/core/src/main/kotlin/common/push/dto/PushMessages.kt
@@ -21,24 +21,21 @@ data class TopicMessage(
 )
 
 /**
- * Message To Send
+ * 푸시 메시지로 전송할 데이터
  */
 data class PushMessage(
     val title: String,
     val body: String,
-    val type: NotificationType,
     val data: Data = Data(emptyMap()),
-    val detailMessage: String? = null,
-    val notify: Boolean = true,
 ) {
     data class Data(val payload: Map<String, String>)
 
-    fun toNotification(userId: String?): Notification {
+    fun toNotification(notificationType: NotificationType, userId: String?): Notification {
         return Notification(
             userId = userId,
             title = title,
-            message = detailMessage ?: body,
-            type = type,
+            message = body,
+            type = notificationType,
         )
     }
 }
@@ -46,11 +43,8 @@ data class PushMessage(
 fun PushMessage(
     title: String,
     body: String,
-    type: NotificationType,
     data: Map<String, String>,
-    detailMessage: String? = null,
-    notify: Boolean = true,
-) = PushMessage(title, body, type, PushMessage.Data(data), detailMessage, notify)
+) = PushMessage(title, body, PushMessage.Data(data))
 
 /**
  * Keys used in Push Message Data
@@ -62,11 +56,8 @@ private object Keys {
 fun PushMessage(
     title: String,
     body: String,
-    type: NotificationType,
     urlScheme: UrlScheme.Compiled,
-    detailMessage: String? = null,
-    notify: Boolean = true,
 ): PushMessage {
     val data = mapOf(Keys.URL_SCHEME to urlScheme.value)
-    return PushMessage(title, body, type, PushMessage.Data(data), detailMessage, notify)
+    return PushMessage(title, body, PushMessage.Data(data))
 }

--- a/core/src/main/kotlin/common/push/dto/PushMessages.kt
+++ b/core/src/main/kotlin/common/push/dto/PushMessages.kt
@@ -29,6 +29,7 @@ data class PushMessage(
     val type: NotificationType,
     val data: Data = Data(emptyMap()),
     val detailMessage: String? = null,
+    val notify: Boolean = true,
 ) {
     data class Data(val payload: Map<String, String>)
 
@@ -36,7 +37,6 @@ data class PushMessage(
         return Notification(
             userId = userId,
             title = title,
-            body = body,
             message = detailMessage ?: body,
             type = type,
         )
@@ -49,7 +49,8 @@ fun PushMessage(
     type: NotificationType,
     data: Map<String, String>,
     detailMessage: String? = null,
-) = PushMessage(title, body, type, PushMessage.Data(data), detailMessage)
+    notify: Boolean = true,
+) = PushMessage(title, body, type, PushMessage.Data(data), detailMessage, notify)
 
 /**
  * Keys used in Push Message Data
@@ -64,7 +65,8 @@ fun PushMessage(
     type: NotificationType,
     urlScheme: UrlScheme.Compiled,
     detailMessage: String? = null,
+    notify: Boolean = true,
 ): PushMessage {
     val data = mapOf(Keys.URL_SCHEME to urlScheme.value)
-    return PushMessage(title, body, type, PushMessage.Data(data), detailMessage)
+    return PushMessage(title, body, type, PushMessage.Data(data), detailMessage, notify)
 }

--- a/core/src/main/kotlin/notification/data/Notification.kt
+++ b/core/src/main/kotlin/notification/data/Notification.kt
@@ -14,6 +14,9 @@ import java.time.LocalDateTime
 data class Notification(
     @Id
     val id: String? = null,
+    /**
+     * null 이면 모든 유저에게 보임
+     */
     @Indexed
     @Field("user_id", targetType = FieldType.OBJECT_ID)
     val userId: String?,

--- a/core/src/main/kotlin/notification/data/Notification.kt
+++ b/core/src/main/kotlin/notification/data/Notification.kt
@@ -18,7 +18,6 @@ data class Notification(
     @Field("user_id", targetType = FieldType.OBJECT_ID)
     val userId: String?,
     val title: String,
-    val body: String,
     val message: String,
     val type: NotificationType,
     @Indexed(direction = IndexDirection.DESCENDING)

--- a/core/src/main/kotlin/notification/data/UserDevice.kt
+++ b/core/src/main/kotlin/notification/data/UserDevice.kt
@@ -9,34 +9,34 @@ import org.springframework.data.mongodb.core.mapping.Field
 import org.springframework.data.mongodb.core.mapping.FieldType
 import java.time.LocalDateTime
 
-@Document("user_devices")
+@Document
 data class UserDevice(
     @Id
     val id: String? = null,
     @Indexed
-    @Field("user_id", targetType = FieldType.OBJECT_ID)
+    @Field(targetType = FieldType.OBJECT_ID)
     val userId: String,
-    @Field("os_type")
+    @Field
     var osType: OsType,
-    @Field("os_version")
+    @Field
     var osVersion: String?,
     @Indexed
-    @Field("device_id")
+    @Field
     var deviceId: String?,
-    @Field("device_model")
+    @Field
     var deviceModel: String?,
-    @Field("app_type")
+    @Field
     var appType: AppType?,
-    @Field("app_version")
+    @Field
     var appVersion: String?,
     @Indexed
-    @Field("fcm_registration_id")
+    @Field
     var fcmRegistrationId: String,
-    @Field("created_at")
+    @Field
     val createdAt: LocalDateTime = LocalDateTime.now(),
-    @Field("updated_at")
+    @Field
     var updatedAt: LocalDateTime = LocalDateTime.now(),
-    @Field("is_deleted")
+    @Field
     var isDeleted: Boolean = false,
 ) {
     companion object {

--- a/core/src/main/kotlin/notification/dto/InsertNotificationRequest.kt
+++ b/core/src/main/kotlin/notification/dto/InsertNotificationRequest.kt
@@ -12,7 +12,7 @@ data class InsertNotificationRequest(
     val userId: String?,
     val title: String,
     val body: String,
-    val insertFcm: Boolean = false,
+    val insertFcm: Boolean,
     val type: NotificationType = NotificationType.NORMAL,
     val dataPayload: Map<String, String> = emptyMap()
 )

--- a/core/src/main/kotlin/notification/dto/NotificationResponse.kt
+++ b/core/src/main/kotlin/notification/dto/NotificationResponse.kt
@@ -11,7 +11,6 @@ data class NotificationResponse(
     @JsonProperty("user_id")
     val userId: String?,
     val title: String,
-    val body: String,
     val message: String,
     val type: NotificationType,
     @JsonProperty("created_at")
@@ -22,7 +21,6 @@ data class NotificationResponse(
             id = notification.id,
             userId = notification.userId,
             title = notification.title,
-            body = notification.body,
             message = notification.message,
             type = notification.type,
             createdAt = notification.createdAt,

--- a/core/src/main/kotlin/notification/service/NotificationAdminService.kt
+++ b/core/src/main/kotlin/notification/service/NotificationAdminService.kt
@@ -21,6 +21,7 @@ class NotificationAdminService(
             request.body,
             request.type,
             request.dataPayload,
+            notify = request.insertFcm,
         )
 
         user?.let {

--- a/core/src/main/kotlin/notification/service/NotificationAdminService.kt
+++ b/core/src/main/kotlin/notification/service/NotificationAdminService.kt
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Service
 
 @Service
 class NotificationAdminService(
-    private val notificationService: NotificationService,
+    private val pushNotificationService: PushNotificationService,
     private val userRepository: UserRepository,
 ) {
     suspend fun insertNotification(request: InsertNotificationRequest) {
@@ -19,15 +19,18 @@ class NotificationAdminService(
         val pushMessage = PushMessage(
             request.title,
             request.body,
-            request.type,
             request.dataPayload,
-            notify = request.insertFcm,
         )
+        val notificationType = request.type
 
-        user?.let {
-            notificationService.sendPush(it.id!!, pushMessage)
-        } ?: run {
-            notificationService.sendGlobalPush(pushMessage)
+        if (request.insertFcm) {
+            user?.let {
+                pushNotificationService.sendPushAndNotification(pushMessage, notificationType, it.id!!)
+            } ?: run {
+                pushNotificationService.sendGlobalPushAndNotification(pushMessage, notificationType)
+            }
+        } else {
+            pushNotificationService.sendNotification(pushMessage.toNotification(notificationType, user?.id))
         }
     }
 }

--- a/core/src/main/kotlin/notification/service/NotificationService.kt
+++ b/core/src/main/kotlin/notification/service/NotificationService.kt
@@ -46,6 +46,7 @@ class NotificationService internal constructor(
     suspend fun sendPush(userId: String, pushMessage: PushMessage) = coroutineScope {
         launch { saveNotification(userId, pushMessage) }
 
+        if (!pushMessage.notify) return@coroutineScope
         launch {
             val userDevices = deviceService.getUserDevices(userId).ifEmpty { return@launch }
 
@@ -57,6 +58,7 @@ class NotificationService internal constructor(
     suspend fun sendPushes(userIds: List<String>, pushMessage: PushMessage) = coroutineScope {
         launch { saveNotifications(userIds, pushMessage) }
 
+        if (!pushMessage.notify) return@coroutineScope
         launch {
             val userIdToDevices = deviceService.getUsersDevices(userIds).ifEmpty { return@launch }
 
@@ -71,6 +73,7 @@ class NotificationService internal constructor(
     suspend fun sendGlobalPush(pushMessage: PushMessage) = coroutineScope {
         launch { saveNotification(userId = null, pushMessage) }
 
+        if (!pushMessage.notify) return@coroutineScope
         launch { pushClient.sendGlobalMessage(pushMessage) }
     }
 

--- a/core/src/main/kotlin/notification/service/PushNotificationService.kt
+++ b/core/src/main/kotlin/notification/service/PushNotificationService.kt
@@ -1,0 +1,114 @@
+package com.wafflestudio.snu4t.notification.service
+
+import com.wafflestudio.snu4t.common.push.PushClient
+import com.wafflestudio.snu4t.common.push.dto.PushMessage
+import com.wafflestudio.snu4t.common.push.dto.PushTargetMessage
+import com.wafflestudio.snu4t.notification.data.Notification
+import com.wafflestudio.snu4t.notification.data.NotificationType
+import com.wafflestudio.snu4t.notification.dto.NotificationQuery
+import com.wafflestudio.snu4t.notification.repository.NotificationRepository
+import com.wafflestudio.snu4t.notification.repository.countUnreadNotifications
+import com.wafflestudio.snu4t.users.data.User
+import com.wafflestudio.snu4t.users.service.UserService
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+
+interface PushNotificationService : PushService, NotificationService {
+    /**
+     * 한 명의 유저에게 푸시를 보내고 알림함에 보이게 합니다.
+     */
+    suspend fun sendPushAndNotification(pushMessage: PushMessage, notificationType: NotificationType, userId: String)
+
+    /**
+     * 복수 명의 유저에게 푸시를 보내고 알림함에 보이게 합니다.
+     */
+    suspend fun sendPushesAndNotifications(pushMessage: PushMessage, notificationType: NotificationType, userIds: List<String>)
+
+    /**
+     * 모든 유저에게 푸시를 보내고 해당 내용이 알림함에 보이게 합니다.
+     */
+    suspend fun sendGlobalPushAndNotification(pushMessage: PushMessage, notificationType: NotificationType)
+}
+
+@Service
+class PushNotificationServiceImpl internal constructor(
+    private val userService: UserService,
+    private val deviceService: DeviceService,
+    private val pushClient: PushClient,
+    private val notificationRepository: NotificationRepository,
+) : PushNotificationService {
+    override suspend fun sendPushAndNotification(
+        pushMessage: PushMessage,
+        notificationType: NotificationType,
+        userId: String,
+    ): Unit = coroutineScope {
+        launch { sendNotification(pushMessage.toNotification(notificationType, userId)) }
+        launch { sendPush(pushMessage, userId) }
+    }
+
+    override suspend fun sendPushesAndNotifications(
+        pushMessage: PushMessage,
+        notificationType: NotificationType,
+        userIds: List<String>,
+    ): Unit = coroutineScope {
+        launch { sendNotifications(userIds.map { pushMessage.toNotification(notificationType, it) }) }
+        launch { sendPushes(pushMessage, userIds) }
+    }
+
+    override suspend fun sendGlobalPushAndNotification(
+        pushMessage: PushMessage,
+        notificationType: NotificationType,
+    ): Unit = coroutineScope {
+        launch { sendNotification(pushMessage.toNotification(notificationType, userId = null)) }
+        launch { pushClient.sendGlobalMessage(pushMessage) }
+    }
+
+    override suspend fun getNotifications(query: NotificationQuery): List<Notification> {
+        val user = query.user
+        val notifications = notificationRepository.findNotifications(
+            userId = user.id!!,
+            createdAt = user.regDate,
+            offset = query.offset,
+            limit = query.limit,
+        ).toList()
+
+        if (query.explicit) {
+            userService.update(user.apply { notificationCheckedAt = LocalDateTime.now() })
+        }
+
+        return notifications
+    }
+
+    override suspend fun getUnreadCount(user: User): Long {
+        return notificationRepository.countUnreadNotifications(user.id!!, user.notificationCheckedAt)
+    }
+
+    override suspend fun sendNotification(notification: Notification) {
+        notificationRepository.save(notification)
+    }
+
+    override suspend fun sendNotifications(notifications: List<Notification>) {
+        notificationRepository.saveAll(notifications).collect()
+    }
+
+    override suspend fun sendPush(pushMessage: PushMessage, userId: String) {
+        val userDevices = deviceService.getUserDevices(userId).ifEmpty { return }
+
+        val pushTargetMessages = userDevices.map { PushTargetMessage(it.fcmRegistrationId, pushMessage) }
+        pushClient.sendMessages(pushTargetMessages)
+    }
+
+    override suspend fun sendPushes(pushMessage: PushMessage, userIds: List<String>) {
+        val userIdToDevices = deviceService.getUsersDevices(userIds).ifEmpty { return }
+
+        val pushTargetMessages = userIdToDevices.values.flatMap { userDevices ->
+            userDevices.map { PushTargetMessage(it.fcmRegistrationId, pushMessage) }
+        }
+
+        pushClient.sendMessages(pushTargetMessages)
+    }
+}

--- a/core/src/main/kotlin/notification/service/PushService.kt
+++ b/core/src/main/kotlin/notification/service/PushService.kt
@@ -1,0 +1,22 @@
+package com.wafflestudio.snu4t.notification.service
+
+import com.wafflestudio.snu4t.common.push.dto.PushMessage
+
+/**
+ * 유저 기기에 푸시를 보내는 서비스입니다.
+ */
+interface PushService {
+    /**
+     * [com.wafflestudio.snu4t.notification.data.Notification]을 저장하지 않고 푸시만 보내므로 사용 시 주의가 필요합니다.
+     *
+     * @see [PushNotificationService.sendPushAndNotification]
+     */
+    suspend fun sendPush(pushMessage: PushMessage, userId: String)
+
+    /**
+     * [com.wafflestudio.snu4t.notification.data.Notification]을 저장하지 않고 푸시만 보내므로 사용 시 주의가 필요합니다.
+     *
+     * @see [PushNotificationService.sendPushesAndNotifications]
+     */
+    suspend fun sendPushes(pushMessage: PushMessage, userIds: List<String>)
+}


### PR DESCRIPTION
#92 의 후속 PR

1. `UserDevice` 의 MongoDB collection, field 이름 camelCase 사용 [관련 슬랙](https://wafflestudio.slack.com/archives/C04T7UW3U8G/p1687785029978359?thread_ts=1687783521.324709&cid=C04T7UW3U8G)
2. `Notification` `body` 제거 [관련 슬랙](https://wafflestudio.slack.com/archives/C04T7UW3U8G/p1687784187748339?thread_ts=1687783521.324709&cid=C04T7UW3U8G)
3. `POST /admin/insert_noti` API 에서 `insertFcm` 로직 누락된 것 대응 [관련 슬랙](https://wafflestudio.slack.com/archives/C04T7UW3U8G/p1687787036555249?thread_ts=1687783559.442109&cid=C04T7UW3U8G)
4. `SugangSnuNotificationService`에서 관심강좌 알림의 경우 fcm 푸시 발송 안 하는 것 대응, NPE 발생 에러 수정 [관련 슬랙](https://wafflestudio.slack.com/archives/C04T7UW3U8G/p1687783559442109)

* * *

5. [수강편람 sync 시 push/notification 로직 기존과 달라진 이슈](https://wafflestudio.slack.com/archives/C0PAVPS5T/p1687850291228009?thread_ts=1687831677.204379&cid=C0PAVPS5T) 해결