### PR TITLE
bypass ssl verification for sugangsnu

### DIFF
--- a/batch/src/main/kotlin/sugangsnu/common/api/SugangSnuLectureApi.kt
+++ b/batch/src/main/kotlin/sugangsnu/common/api/SugangSnuLectureApi.kt
@@ -1,9 +1,13 @@
 package com.wafflestudio.snu4t.sugangsnu.common.api
 
+import io.netty.handler.ssl.SslContextBuilder
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.client.reactive.ReactorClientHttpConnector
 import org.springframework.web.reactive.function.client.ExchangeStrategies
 import org.springframework.web.reactive.function.client.WebClient
+import reactor.netty.http.client.HttpClient
 
 @Configuration
 class SugangSnuApiConfig() {
@@ -17,7 +21,20 @@ class SugangSnuApiConfig() {
             .codecs { it.defaultCodecs().maxInMemorySize(-1) } // to unlimited memory size
             .build()
 
-        return WebClient.builder().baseUrl(SUGANG_SNU_BASEURL)
+        // FIXME: This is a temporary solution to bypass SSL verification
+        val httpClient = HttpClient.create()
+            .secure {
+                it.sslContext(
+                    SslContextBuilder
+                        .forClient()
+                        .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                        .build()
+                )
+            }
+
+        return WebClient.builder()
+            .clientConnector(ReactorClientHttpConnector(httpClient))
+            .baseUrl(SUGANG_SNU_BASEURL)
             .exchangeStrategies(exchangeStrategies) // set exchange strategies
             .defaultHeaders {
                 it.setAll(


### PR DESCRIPTION
일단 수강편람 batch 가 동작해야하는데, java keystore 에 직접 갱신된 sugang.snu.ac.kr 인증서 넣는 등 이리저리 해봐도 안 되어서 급한대로 ssl verification bypass 합니다. 좋은 방법은 아닙니다.

javax.net.ssl.SSLHandshakeException: PKIX path validation failed: java.security.cert.CertPathValidatorException: validity check failed