### PR TITLE
Dup email check when register

### DIFF
--- a/core/src/main/kotlin/common/exception/ErrorType.kt
+++ b/core/src/main/kotlin/common/exception/ErrorType.kt
@@ -19,7 +19,7 @@ enum class ErrorType(
 
     INVALID_LOCAL_ID(HttpStatus.FORBIDDEN, 0x3000, "localId가 유효하지 않습니다.", "아이디는 4~32자의 영문자와 숫자로 이루어져야 합니다."),
     INVALID_PASSWORD(HttpStatus.FORBIDDEN, 0x3001, "password가 유효하지 않습니다.", "비밀번호는 6~20자로 영문자와 숫자를 모두 포함해야 합니다."),
-    DUPLICATE_LOCAL_ID(HttpStatus.FORBIDDEN, 0x3002, "localId가 중복되었습니다.", "이미 사용중인 아이디입니다."),
+    DUPLICATE_LOCAL_ID(HttpStatus.FORBIDDEN, 0x3002, "localId가 중복되었습니다.", "이미 사용 중인 아이디입니다."),
     INVALID_EMAIL(HttpStatus.FORBIDDEN, 0x300F, "email이 유효하지 않습니다.", "이메일 형식이 올바르지 않습니다."),
 
     LECTURE_NOT_FOUND(HttpStatus.NOT_FOUND, 0x4003, "lecture가 없습니다.", "해당 강의는 존재하지 않습니다."),
@@ -39,7 +39,8 @@ enum class ErrorType(
     NO_USER_FCM_KEY(HttpStatus.NOT_FOUND, 40402, "유저 FCM 키가 존재하지 않습니다."),
     CONFIG_NOT_FOUND(HttpStatus.NOT_FOUND, 40403, "config가 존재하지 않습니다."),
 
-    DUPLICATE_VACANCY_NOTIFICATION(HttpStatus.BAD_REQUEST, 40900, "빈자리 알림 중복"),
+    DUPLICATE_VACANCY_NOTIFICATION(HttpStatus.CONFLICT, 40900, "빈자리 알림 중복"),
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, 40901, "이미 사용 중인 이메일입니다."),
 
     DYNAMIC_LINK_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 50001, "링크 생성 실패", "링크 생성에 실패했습니다. 잠시 후 다시 시도해주세요."),
 }

--- a/core/src/main/kotlin/common/exception/Snu4tException.kt
+++ b/core/src/main/kotlin/common/exception/Snu4tException.kt
@@ -43,5 +43,6 @@ object SharedTimetableNotFoundException : Snu4tException(ErrorType.SHARED_TIMETA
 object ConfigNotFoundException : Snu4tException(ErrorType.CONFIG_NOT_FOUND)
 
 object DuplicateVacancyNotificationException : Snu4tException(ErrorType.DUPLICATE_VACANCY_NOTIFICATION)
+object DuplicateEmailException : Snu4tException(ErrorType.DUPLICATE_EMAIL)
 
 object DynamicLinkGenerationFailedException : Snu4tException(ErrorType.DYNAMIC_LINK_GENERATION_FAILED)

--- a/core/src/main/kotlin/users/repository/UserRepository.kt
+++ b/core/src/main/kotlin/users/repository/UserRepository.kt
@@ -15,5 +15,7 @@ interface UserRepository : CoroutineCrudRepository<User, String> {
 
     suspend fun findByCredentialLocalIdAndActiveTrue(localId: String): User?
 
+    suspend fun existsByEmailAndIsEmailVerifiedTrueAndActiveTrue(email: String): Boolean
+
     fun findAllByNicknameStartingWith(nickname: String): Flow<User>
 }

--- a/core/src/main/kotlin/users/service/UserService.kt
+++ b/core/src/main/kotlin/users/service/UserService.kt
@@ -2,6 +2,7 @@ package com.wafflestudio.snu4t.users.service
 
 import com.wafflestudio.snu4t.common.cache.Cache
 import com.wafflestudio.snu4t.common.cache.CacheKey
+import com.wafflestudio.snu4t.common.exception.DuplicateEmailException
 import com.wafflestudio.snu4t.common.exception.DuplicateLocalIdException
 import com.wafflestudio.snu4t.common.exception.InvalidEmailException
 import com.wafflestudio.snu4t.common.exception.InvalidLocalIdException
@@ -57,7 +58,10 @@ class UserServiceImpl(
 
             if (!authService.isValidLocalId(localId)) throw InvalidLocalIdException
             if (!authService.isValidPassword(password)) throw InvalidPasswordException
-            email?.let { if (!authService.isValidEmail(email)) throw InvalidEmailException }
+            email?.let {
+                if (!authService.isValidEmail(email)) throw InvalidEmailException
+                if (userRepository.existsByEmailAndIsEmailVerifiedTrueAndActiveTrue(email)) throw DuplicateEmailException
+            }
 
             if (userRepository.existsByCredentialLocalIdAndActiveTrue(localId)) throw DuplicateLocalIdException
 


### PR DESCRIPTION
https://www.notion.so/wafflestudio/cd17a10ea3454419be1cf963c28ad69a?pvs=4

유저의 혼란 최소화를 위해, 가입 시 기존에 학교 인증한 이메일은 새로운 유저의 정보로 넣지 못하도록 함
(추후 유저 정보 수정 API (`PUT /v1/user/info`) 에도 반영 필요)