### PR TITLE
친구 추가 링크 수락 시 응답에 상대방 정보 추가

### DIFF
--- a/api/src/main/kotlin/handler/FriendHandler.kt
+++ b/api/src/main/kotlin/handler/FriendHandler.kt
@@ -1,7 +1,6 @@
 package com.wafflestudio.snu4t.handler
 
 import com.wafflestudio.snu4t.common.dto.ListResponse
-import com.wafflestudio.snu4t.common.dto.OkResponse
 import com.wafflestudio.snu4t.friend.dto.FriendRequest
 import com.wafflestudio.snu4t.friend.dto.FriendRequestLinkResponse
 import com.wafflestudio.snu4t.friend.dto.FriendResponse
@@ -90,6 +89,15 @@ class FriendHandler(
         val requestToken = req.pathVariable("requestToken")
 
         friendService.acceptFriendByLink(userId, requestToken)
-        OkResponse()
+            .let {
+                (friend, partner) ->
+                FriendResponse(
+                    id = friend.id!!,
+                    userId = partner.id!!,
+                    displayName = friend.getPartnerDisplayName(userId),
+                    nickname = userNicknameService.getNicknameDto(partner.nickname!!),
+                    createdAt = friend.createdAt,
+                )
+            }
     }
 }

--- a/api/src/main/kotlin/router/docs/FriendDocs.kt
+++ b/api/src/main/kotlin/router/docs/FriendDocs.kt
@@ -1,7 +1,6 @@
 package com.wafflestudio.snu4t.router.docs
 
 import com.wafflestudio.snu4t.common.dto.ListResponse
-import com.wafflestudio.snu4t.common.dto.OkResponse
 import com.wafflestudio.snu4t.coursebook.data.CoursebookDto
 import com.wafflestudio.snu4t.friend.dto.FriendRequest
 import com.wafflestudio.snu4t.friend.dto.FriendRequestLinkResponse
@@ -108,7 +107,7 @@ import org.springframework.web.bind.annotation.RequestMethod
         path = "/v1/friends/accept-link/{requestToken}", method = [RequestMethod.POST], produces = [MediaType.APPLICATION_JSON_VALUE],
         operation = Operation(
             operationId = "acceptFriendByLink",
-            responses = [ApiResponse(responseCode = "200", content = [Content(schema = Schema(implementation = OkResponse::class))])]
+            responses = [ApiResponse(responseCode = "200", content = [Content(schema = Schema(implementation = FriendResponse::class))])]
         ),
     ),
 )


### PR DESCRIPTION
https://wafflestudio.slack.com/archives/C0PAVPS5T/p1720953078832549?thread_ts=1720872462.112309&cid=C0PAVPS5T
수락한 친구로 화면 전환하는 기능을 위해 응답 형식을 FriendResponse로 변경했습니다