### PR TITLE
강의 시간 수정 시 한 강좌 안에서 시간 겹칠 때 오류 수정

### DIFF
--- a/core/src/main/kotlin/timetables/service/TimetableLectureService.kt
+++ b/core/src/main/kotlin/timetables/service/TimetableLectureService.kt
@@ -106,7 +106,9 @@ class TimetableLectureServiceImpl(
     ): Timetable {
         val timetable = timetableRepository.findByUserIdAndId(userId, timetableId) ?: throw TimetableNotFoundException
         val timetableLecture = timetable.lectures.find { it.id == timetableLectureId } ?: throw LectureNotFoundException
-        if (ClassTimeUtils.timesOverlap(timetableLecture.classPlaceAndTimes)) throw InvalidTimeException
+        val newClassPlaceAndTimes = modifyTimetableLectureRequestDto.classPlaceAndTimes?.map { it.toClassPlaceAndTime() }
+            ?: timetableLecture.classPlaceAndTimes
+        if (ClassTimeUtils.timesOverlap(newClassPlaceAndTimes)) throw InvalidTimeException
         timetableLecture.apply {
             courseTitle = modifyTimetableLectureRequestDto.courseTitle ?: courseTitle
             academicYear = modifyTimetableLectureRequestDto.academicYear ?: academicYear
@@ -117,8 +119,7 @@ class TimetableLectureServiceImpl(
             remark = modifyTimetableLectureRequestDto.remark ?: remark
             color = modifyTimetableLectureRequestDto.color ?: color
             colorIndex = modifyTimetableLectureRequestDto.colorIndex ?: colorIndex
-            classPlaceAndTimes = modifyTimetableLectureRequestDto.classPlaceAndTimes?.map { it.toClassPlaceAndTime() }
-                ?: classPlaceAndTimes
+            classPlaceAndTimes = newClassPlaceAndTimes
         }
         resolveTimeConflict(timetable, timetableLecture, isForced)
         return timetableRepository.updateTimetableLecture(timetableId, timetableLecture)


### PR DESCRIPTION
스크럼에서 얘기가 나와서 보니 강의 수정할때 한 강좌 안에서 시간 겹치는지 검사하는게 바뀐 시간이 아니라 현재 저장된 걸 기준으로 하고 있는데 그게 의도가 아닌거 같아서 새로 요청 온걸 검사하도록 바꾸었습니다