### PR TITLE
소셜로그인 시에 강의평 이메일 인증 여부 false로 설정, 인증받을때 스누메일인지 체크

### DIFF
--- a/core/src/main/kotlin/users/service/AuthService.kt
+++ b/core/src/main/kotlin/users/service/AuthService.kt
@@ -20,6 +20,8 @@ interface AuthService {
 
     fun isValidEmail(email: String): Boolean
 
+    fun isValidSnuMail(email: String): Boolean
+
     fun isMatchedPassword(
         user: User,
         password: String,
@@ -64,6 +66,8 @@ class AuthServiceImpl(
     override fun isValidPassword(password: String) = password.matches(passwordRegex)
 
     override fun isValidEmail(email: String) = email.matches(emailRegex)
+
+    override fun isValidSnuMail(email: String) = email.matches(emailRegex) && email.endsWith("@snu.ac.kr")
 
     override fun isMatchedPassword(
         user: User,

--- a/core/src/main/kotlin/users/service/UserService.kt
+++ b/core/src/main/kotlin/users/service/UserService.kt
@@ -222,7 +222,7 @@ class UserServiceImpl(
             log.warn("facebook email is null: $oauth2UserResponse")
         }
 
-        return signup(credential, oauth2UserResponse.email, oauth2UserResponse.isEmailVerified)
+        return signup(credential, oauth2UserResponse.email, false)
     }
 
     override suspend fun loginGoogle(socialLoginRequest: SocialLoginRequest): LoginResponse {
@@ -245,7 +245,7 @@ class UserServiceImpl(
 
         val credential = authService.buildGoogleCredential(oauth2UserResponse)
 
-        return signup(credential, oauth2UserResponse.email, oauth2UserResponse.isEmailVerified)
+        return signup(credential, oauth2UserResponse.email, false)
     }
 
     override suspend fun loginKakao(socialLoginRequest: SocialLoginRequest): LoginResponse {
@@ -268,7 +268,7 @@ class UserServiceImpl(
 
         val credential = authService.buildKakaoCredential(oauth2UserResponse)
 
-        return signup(credential, oauth2UserResponse.email, oauth2UserResponse.isEmailVerified)
+        return signup(credential, oauth2UserResponse.email, false)
     }
 
     private fun getSocialProvider(user: User): SocialProvider {
@@ -326,7 +326,7 @@ class UserServiceImpl(
         email: String,
     ) {
         if (user.isEmailVerified == true) throw EmailAlreadyVerifiedException
-        if (!authService.isValidEmail(email)) throw InvalidEmailException
+        if (!authService.isValidSnuMail(email)) throw InvalidEmailException
         if (userRepository.existsByEmailAndIsEmailVerifiedTrueAndActiveTrue(email)) throw DuplicateEmailException(getSocialProvider(user))
         val key = VERIFICATION_CODE_PREFIX + user.id
         val code = (Math.random() * 1000000).toInt().toString().padStart(6, '0')


### PR DESCRIPTION
소셜로그인의 isEmailVerified가 그대로 넘어오는게 강의평 인증 여부를 나타내는 의미랑 안맞는거 같아서 고쳤고 강의평 인증받을때 클라이언트가 스누메일만 보내고 있긴 한데 한번 더 검증하게 추가했습니다