### PR TITLE
강의계획서 프록시 안한 url 제공

### DIFF
--- a/api/src/main/kotlin/handler/CoursebookHandler.kt
+++ b/api/src/main/kotlin/handler/CoursebookHandler.kt
@@ -39,8 +39,8 @@ class CoursebookHandler(
                     lectureNumber = req.parseRequiredQueryParam("lecture_number"),
                 )
             CoursebookOfficialResponse(
-                url = REDIRECT_PREFIX_URL + url,
-                rawUrl = url,
+                noProxyUrl = url,
+                proxyUrl = REDIRECT_PREFIX_URL + url,
             )
         }
 }

--- a/api/src/main/kotlin/handler/CoursebookHandler.kt
+++ b/api/src/main/kotlin/handler/CoursebookHandler.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.snu4t.handler
 
 import com.wafflestudio.snu4t.common.enum.Semester
+import com.wafflestudio.snu4t.common.util.SugangSnuUrlUtils.REDIRECT_PREFIX_URL
 import com.wafflestudio.snu4t.common.util.SugangSnuUrlUtils.parseSyllabusUrl
 import com.wafflestudio.snu4t.coursebook.data.CoursebookOfficialResponse
 import com.wafflestudio.snu4t.coursebook.data.CoursebookResponse
@@ -37,6 +38,9 @@ class CoursebookHandler(
                     courseNumber = req.parseRequiredQueryParam("course_number"),
                     lectureNumber = req.parseRequiredQueryParam("lecture_number"),
                 )
-            CoursebookOfficialResponse(url)
+            CoursebookOfficialResponse(
+                url = REDIRECT_PREFIX_URL + url,
+                rawUrl = url,
+            )
         }
 }

--- a/core/src/main/kotlin/common/util/SugangSnuUrlUtils.kt
+++ b/core/src/main/kotlin/common/util/SugangSnuUrlUtils.kt
@@ -4,13 +4,7 @@ import com.wafflestudio.snu4t.common.enum.Semester
 import org.springframework.web.util.DefaultUriBuilderFactory
 
 object SugangSnuUrlUtils {
-    val redirectPrefixUrl =
-        DefaultUriBuilderFactory().builder()
-            .scheme("http")
-            .host("libproxy.snu.ac.kr")
-            .path("/_Lib_Proxy_Url/")
-            .build()
-            .toString()
+    const val REDIRECT_PREFIX_URL = "https://libproxy.snu.ac.kr/_Lib_Proxy_Url/"
 
     fun convertSemesterToSugangSnuSearchString(semester: Semester): String =
         when (semester) {
@@ -26,19 +20,18 @@ object SugangSnuUrlUtils {
         courseNumber: String,
         lectureNumber: String,
     ): String =
-        redirectPrefixUrl +
-            DefaultUriBuilderFactory().builder()
-                .scheme("https")
-                .host("sugang.snu.ac.kr")
-                .path("/sugang/cc/cc103.action")
-                .queryParam("openSchyy", year)
-                .queryParam("openShtmFg", makeOpenShtmFg(semester))
-                .queryParam("openDetaShtmFg", makeOpenDetaShtmFg(semester))
-                .queryParam("sbjtCd", courseNumber)
-                .queryParam("ltNo", lectureNumber)
-                .queryParam("sbjtSubhCd", "000")
-                .build()
-                .toString()
+        DefaultUriBuilderFactory().builder()
+            .scheme("https")
+            .host("sugang.snu.ac.kr")
+            .path("/sugang/cc/cc103.action")
+            .queryParam("openSchyy", year)
+            .queryParam("openShtmFg", makeOpenShtmFg(semester))
+            .queryParam("openDetaShtmFg", makeOpenDetaShtmFg(semester))
+            .queryParam("sbjtCd", courseNumber)
+            .queryParam("ltNo", lectureNumber)
+            .queryParam("sbjtSubhCd", "000")
+            .build()
+            .toString()
 
     private fun makeOpenShtmFg(semester: Semester) =
         when (semester) {

--- a/core/src/main/kotlin/coursebook/data/CoursebookOfficialResponse.kt
+++ b/core/src/main/kotlin/coursebook/data/CoursebookOfficialResponse.kt
@@ -2,4 +2,5 @@ package com.wafflestudio.snu4t.coursebook.data
 
 data class CoursebookOfficialResponse(
     val url: String,
+    val rawUrl: String? = null,
 )

--- a/core/src/main/kotlin/coursebook/data/CoursebookOfficialResponse.kt
+++ b/core/src/main/kotlin/coursebook/data/CoursebookOfficialResponse.kt
@@ -1,6 +1,8 @@
 package com.wafflestudio.snu4t.coursebook.data
 
 data class CoursebookOfficialResponse(
-    val url: String,
-    val rawUrl: String? = null,
+    val noProxyUrl: String,
+    val proxyUrl: String?,
+    // 구버전 대응용 url 필드, 추후 삭제
+    val url: String = proxyUrl ?: noProxyUrl,
 )


### PR DESCRIPTION
https://wafflestudio.slack.com/archives/C0PAVPS5T/p1729768106297699?thread_ts=1728361353.404059&cid=C0PAVPS5T
앱에서 referer 헤더 적용이 가능한 경우 proxy를 쓰지 않도록 url을 2개 보내주는게 좋겠다고 하네요
prefix는 바뀔일 없어서 그냥 상수로 처리했습니다