### PR TITLE
custom HS256 사용으로 jwt secret 길이 제한 우회

### DIFF
--- a/api/src/main/kotlin/middleware/ApiKeyMiddleware.kt
+++ b/api/src/main/kotlin/middleware/ApiKeyMiddleware.kt
@@ -3,6 +3,7 @@ package com.wafflestudio.snutt.middleware
 import com.wafflestudio.snutt.common.exception.WrongApiKeyException
 import com.wafflestudio.snutt.handler.RequestContext
 import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.security.MacAlgorithm
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.server.ServerRequest
@@ -12,8 +13,33 @@ import javax.crypto.spec.SecretKeySpec
 class ApiKeyMiddleware(
     @Value("\${snutt.secret-key}") private val secretKey: String,
 ) : Middleware {
-    private val keySpec = SecretKeySpec(secretKey.toByteArray(), "HmacSHA256")
-    private val jwtParser = Jwts.parser().verifyWith(keySpec).build()
+    companion object {
+        const val API_KEY_HEADER = "x-access-apikey"
+        const val HMAC_SHA256_ALGORITHM_ID = "HS256"
+        const val HMAC_SHA256_JCA_NAME = "HmacSHA256"
+        const val DEFAULT_MAC_ALGORITHM_CLASS = "io.jsonwebtoken.impl.security.DefaultMacAlgorithm"
+    }
+
+    private val keySpec = SecretKeySpec(secretKey.toByteArray(), HMAC_SHA256_JCA_NAME)
+
+    private val customHS256 =
+        run {
+            val minKeyBitLength = 80
+            Class
+                .forName(DEFAULT_MAC_ALGORITHM_CLASS)
+                .getDeclaredConstructor(String::class.java, String::class.java, Int::class.java)
+                .apply { isAccessible = true }
+                .newInstance(HMAC_SHA256_ALGORITHM_ID, HMAC_SHA256_JCA_NAME, minKeyBitLength) as MacAlgorithm
+        }
+    private val jwtParser =
+        Jwts
+            .parser()
+            .verifyWith(keySpec)
+            .sig()
+            .remove(Jwts.SIG.HS256)
+            .add(customHS256)
+            .and()
+            .build()
     private val stringToKeyVersionMap =
         mapOf(
             "ios" to "0",
@@ -27,7 +53,7 @@ class ApiKeyMiddleware(
         context: RequestContext,
     ): RequestContext =
         runCatching {
-            val apiKey = requireNotNull(req.headers().firstHeader("x-access-apikey"))
+            val apiKey = requireNotNull(req.headers().firstHeader(API_KEY_HEADER))
             val claims = jwtParser.parseSignedClaims(apiKey).payload
 
             val string = claims["string"]!!.toString()


### PR DESCRIPTION
https://github.com/jwtk/jjwt/issues/521 참고하였습니다
jjwt 0.10.0부터 기존에 apikey 만든 secret이 WeakKeyException을 띄우네요