### PR TITLE
강의실명 regex 변경

### DIFF
--- a/core/src/main/kotlin/lectures/repository/LectureCustomRepository.kt
+++ b/core/src/main/kotlin/lectures/repository/LectureCustomRepository.kt
@@ -29,7 +29,7 @@ class LectureCustomRepositoryImpl(
     private val reactiveMongoTemplate: ReactiveMongoTemplate,
 ) : LectureCustomRepository {
     companion object {
-        private val placeRegex = """^\d+(?:-\d+)?(?:-\d+)?-[A-Z]?\d+[A-Z]?$""".toRegex()
+        private val placeRegex = """^(?:|#|\*)\d+(?:-\d+)?(?:-\d+)?-[A-Z]?\d+[A-Z]?$""".toRegex()
         private val buildingRegex = """^\d+(?:-\d+)?동$""".toRegex()
     }
 

--- a/core/src/main/kotlin/lectures/repository/LectureCustomRepository.kt
+++ b/core/src/main/kotlin/lectures/repository/LectureCustomRepository.kt
@@ -29,7 +29,7 @@ class LectureCustomRepositoryImpl(
     private val reactiveMongoTemplate: ReactiveMongoTemplate,
 ) : LectureCustomRepository {
     companion object {
-        private val placeRegex = """^\d+-\d+(?:-\d+)?(?:-\d+)?$""".toRegex()
+        private val placeRegex = """^\d+(?:-\d+)?(?:-\d+)?-[A-Z]?\d+[A-Z]?$""".toRegex()
         private val buildingRegex = """^\d+(?:-\d+)?동$""".toRegex()
     }
 

--- a/core/src/main/kotlin/lectures/repository/LectureCustomRepository.kt
+++ b/core/src/main/kotlin/lectures/repository/LectureCustomRepository.kt
@@ -29,7 +29,7 @@ class LectureCustomRepositoryImpl(
     private val reactiveMongoTemplate: ReactiveMongoTemplate,
 ) : LectureCustomRepository {
     companion object {
-        private val placeRegex = """^(?:|#|\*)\d+(?:-\d+)?(?:-\d+)?-[A-Z]?\d+[A-Z]?$""".toRegex()
+        private val placeRegex = """^(?:|#|\*)\d+(?:-\d+|-[A-Z])?-[A-Z]?\d+[A-Z]?(?:-\d+)?$""".toRegex()
         private val buildingRegex = """^\d+(?:-\d+)?동$""".toRegex()
     }
 


### PR DESCRIPTION
연건, 평창캠퍼스 강의실의 경우 앞에 # 또는 *가 붙어서 그것도 인식하게 했고
강의실 호수에 알파벳이 들어가는 경우도 검색이 가능하게 했어요