### PR TITLE
[강의 리마인더] DTO 및 API 수정

### DIFF
--- a/api/src/main/kotlin/handler/TimetableLectureReminderHandler.kt
+++ b/api/src/main/kotlin/handler/TimetableLectureReminderHandler.kt
@@ -18,13 +18,19 @@ class TimetableLectureReminderHandler(
         handle(req) {
             val timetableId = req.pathVariable("timetableId")
             val timetableLectureId = req.pathVariable("timetableLectureId")
-            timetableLectureReminderService.getReminder(timetableId, timetableLectureId)?.let(::TimetableLectureReminderDto)
+
+            timetableLectureReminderService
+                .getReminder(timetableId, timetableLectureId)
+                .let(::TimetableLectureReminderDto)
         }
 
     suspend fun getReminders(req: ServerRequest): ServerResponse =
         handle(req) {
             val timetableId = req.pathVariable("timetableId")
-            timetableLectureReminderService.getReminders(timetableId).map(::TimetableLectureReminderDto)
+
+            timetableLectureReminderService
+                .getReminders(timetableId)
+                .map(::TimetableLectureReminderDto)
         }
 
     suspend fun modifyReminder(req: ServerRequest): ServerResponse =
@@ -32,17 +38,12 @@ class TimetableLectureReminderHandler(
             val timetableId = req.pathVariable("timetableId")
             val timetableLectureId = req.pathVariable("timetableLectureId")
             val body = req.awaitBody<TimetableLectureReminderModifyRequestDto>()
+
             timetableLectureReminderService
                 .modifyReminder(
                     timetableId,
                     timetableLectureId,
-                    body.offsetMinutes,
+                    body.option,
                 ).let(::TimetableLectureReminderDto)
-        }
-
-    suspend fun deleteReminder(req: ServerRequest): ServerResponse =
-        handle(req) {
-            val timetableLectureId = req.pathVariable("timetableLectureId")
-            timetableLectureReminderService.deleteReminder(timetableLectureId)
         }
 }

--- a/api/src/main/kotlin/router/MainRouter.kt
+++ b/api/src/main/kotlin/router/MainRouter.kt
@@ -166,7 +166,6 @@ class MainRouter(
                     DELETE("/{timetableLectureId}", timeTableLectureHandler::deleteTimetableLecture)
                     GET("/{timetableLectureId}/reminder", timetableLectureReminderHandler::getReminder)
                     PUT("/{timetableLectureId}/reminder", timetableLectureReminderHandler::modifyReminder)
-                    DELETE("/{timetableLectureId}/reminder", timetableLectureReminderHandler::deleteReminder)
                     GET("/reminders", timetableLectureReminderHandler::getReminders)
                 }
             }

--- a/api/src/main/kotlin/router/docs/TimetableDocs.kt
+++ b/api/src/main/kotlin/router/docs/TimetableDocs.kt
@@ -447,7 +447,7 @@ import timetables.dto.TimetableBriefDto
                 requestBody =
                     RequestBody(
                         required = true,
-                        description = "강의 리마인더 설정 옵션 (없음, 10분전, 0분, 10분후)",
+                        description = "강의 리마인더 설정 옵션 (NONE, BEFORE_TEN_MINUTES, ZERO_MINUTE, AFTER_TEN_MINUTES)",
                         content = [
                             Content(
                                 schema = Schema(implementation = TimetableLectureReminderModifyRequestDto::class),

--- a/api/src/main/kotlin/router/docs/TimetableDocs.kt
+++ b/api/src/main/kotlin/router/docs/TimetableDocs.kt
@@ -447,7 +447,7 @@ import timetables.dto.TimetableBriefDto
                 requestBody =
                     RequestBody(
                         required = true,
-                        description = "강의 시작 시각으로부터 알림을 받을 시간의 오프셋(분)",
+                        description = "강의 리마인더 설정 옵션 (없음, 10분전, 0분, 10분후)",
                         content = [
                             Content(
                                 schema = Schema(implementation = TimetableLectureReminderModifyRequestDto::class),
@@ -458,33 +458,6 @@ import timetables.dto.TimetableBriefDto
                     ApiResponse(
                         responseCode = "200",
                         content = [Content(schema = Schema(implementation = TimetableLectureReminderDto::class))],
-                    ),
-                ],
-            ),
-    ),
-    RouterOperation(
-        path = "/v1/tables/{timetableId}/lecture/{timetableLectureId}/reminder",
-        method = [RequestMethod.DELETE],
-        produces = [MediaType.APPLICATION_JSON_VALUE],
-        operation =
-            Operation(
-                operationId = "deleteReminder",
-                parameters = [
-                    Parameter(
-                        `in` = ParameterIn.PATH,
-                        name = "timetableId",
-                        required = true,
-                    ),
-                    Parameter(
-                        `in` = ParameterIn.PATH,
-                        name = "timetableLectureId",
-                        required = true,
-                    ),
-                ],
-                responses = [
-                    ApiResponse(
-                        responseCode = "200",
-                        content = [Content(schema = Schema(implementation = Unit::class))],
                     ),
                 ],
             ),

--- a/core/src/main/kotlin/timetablelecturereminder/data/TimetableLectureAndReminder.kt
+++ b/core/src/main/kotlin/timetablelecturereminder/data/TimetableLectureAndReminder.kt
@@ -1,0 +1,8 @@
+package com.wafflestudio.snutt.timetablelecturereminder.data
+
+import com.wafflestudio.snutt.timetables.data.TimetableLecture
+
+data class TimetableLectureAndReminder(
+    val timetableLecture: TimetableLecture,
+    val reminder: TimetableLectureReminder?,
+)

--- a/core/src/main/kotlin/timetablelecturereminder/dto/TimetableLectureReminderDto.kt
+++ b/core/src/main/kotlin/timetablelecturereminder/dto/TimetableLectureReminderDto.kt
@@ -1,16 +1,19 @@
 package com.wafflestudio.snutt.timetablelecturereminder.dto
 
-import com.wafflestudio.snutt.timetablelecturereminder.data.TimetableLectureReminder
+import com.wafflestudio.snutt.timetablelecturereminder.data.TimetableLectureAndReminder
 
 data class TimetableLectureReminderDto(
-    val id: String,
     val timetableLectureId: String,
-    val offsetMinutes: Int,
+    val courseTitle: String,
+    val option: TimetableLectureReminderOption,
 )
 
-fun TimetableLectureReminderDto(timetableLectureReminder: TimetableLectureReminder): TimetableLectureReminderDto =
+fun TimetableLectureReminderDto(timetableLectureAndReminder: TimetableLectureAndReminder): TimetableLectureReminderDto =
     TimetableLectureReminderDto(
-        id = timetableLectureReminder.id!!,
-        timetableLectureId = timetableLectureReminder.timetableLectureId,
-        offsetMinutes = timetableLectureReminder.offsetMinutes,
+        timetableLectureId = timetableLectureAndReminder.timetableLecture.id,
+        courseTitle = timetableLectureAndReminder.timetableLecture.courseTitle,
+        option =
+            timetableLectureAndReminder.reminder?.let {
+                TimetableLectureReminderOption.fromOffsetMinutes(it.offsetMinutes)
+            } ?: TimetableLectureReminderOption.NONE,
     )

--- a/core/src/main/kotlin/timetablelecturereminder/dto/TimetableLectureReminderOption.kt
+++ b/core/src/main/kotlin/timetablelecturereminder/dto/TimetableLectureReminderOption.kt
@@ -5,7 +5,7 @@ enum class TimetableLectureReminderOption(
 ) {
     NONE(null),
     TEN_MINUTES_BEFORE(-10),
-    ZERO_MINUTES(0),
+    ZERO_MINUTE(0),
     TEN_MINUTES_AFTER(10),
     ;
 
@@ -14,7 +14,7 @@ enum class TimetableLectureReminderOption(
             when (offsetMinutes) {
                 null -> NONE
                 -10 -> TEN_MINUTES_BEFORE
-                0 -> ZERO_MINUTES
+                0 -> ZERO_MINUTE
                 10 -> TEN_MINUTES_AFTER
                 else -> throw IllegalArgumentException("Invalid offsetMinutes: $offsetMinutes")
             }

--- a/core/src/main/kotlin/timetablelecturereminder/dto/TimetableLectureReminderOption.kt
+++ b/core/src/main/kotlin/timetablelecturereminder/dto/TimetableLectureReminderOption.kt
@@ -1,0 +1,22 @@
+package com.wafflestudio.snutt.timetablelecturereminder.dto
+
+enum class TimetableLectureReminderOption(
+    val offsetMinutes: Int?,
+) {
+    NONE(null),
+    TEN_MINUTES_BEFORE(-10),
+    ZERO_MINUTES(0),
+    TEN_MINUTES_AFTER(10),
+    ;
+
+    companion object {
+        fun fromOffsetMinutes(offsetMinutes: Int?): TimetableLectureReminderOption =
+            when (offsetMinutes) {
+                null -> NONE
+                -10 -> TEN_MINUTES_BEFORE
+                0 -> ZERO_MINUTES
+                10 -> TEN_MINUTES_AFTER
+                else -> throw IllegalArgumentException("Invalid offsetMinutes: $offsetMinutes")
+            }
+    }
+}

--- a/core/src/main/kotlin/timetablelecturereminder/dto/request/TimetableLectureReminderModifyRequestDto.kt
+++ b/core/src/main/kotlin/timetablelecturereminder/dto/request/TimetableLectureReminderModifyRequestDto.kt
@@ -1,5 +1,7 @@
 package com.wafflestudio.snutt.timetablelecturereminder.dto.request
 
+import com.wafflestudio.snutt.timetablelecturereminder.dto.TimetableLectureReminderOption
+
 data class TimetableLectureReminderModifyRequestDto(
-    val offsetMinutes: Int,
+    val option: TimetableLectureReminderOption,
 )


### PR DESCRIPTION
## 요약
- DB에 리마인더 document가 존재하지 않더라도, 클라 입장에서는 '없음' 상태로 존재하는 것처럼 보이도록 DTO와 API를 수정합니다.
## 문제 상황
- 기존 방식에서는 더보기탭 화면에서 시간표의 모든 강의리마인더를 보여주기 위해, 클라에서 시간표 조회 API와 리마인더 다건 조회 API를 모두 찌르고 두 결과를 join해야 했음
- 클라에서 처리하기에 복잡한 로직이고, 서버 측 리마인더 document의 존재 사실을 명확하게 알릴 필요도 없을 것 같아서
- 이와 같이 변경합니다.
## 변경 사항
- TimetableLectureReminderDTO에서 offsetMinutes 필드 제거하고, option이라는 enum 필드로 대신함
  - 하위호환을 챙기기는 어려운 구조지만, 변경될 여지가 많이 없다고 판단하고 이렇게 진행
  - 추가로 id 필드도 없어졌음. 리마인더가 없는 경우 id = null으로 내려가는 게 어색하고, 식별은 timetableLectureId로 가능하기 때문
- TimetableLectureReminderDTO에 courseTitle 필드 추가
- DELETE api 제거하고, PUT api로 대신함
  - 이제 리마인더 등록 해제가 '삭제'가 아닌 '옵션 변경'으로 취급되기 때문에, DELETE은 없애고 PUT으로 합침
## Reference
- [슬랙 논의](https://wafflestudio.slack.com/archives/C0PAVPS5T/p1759548167441999?thread_ts=1757153125.685969&cid=C0PAVPS5T)