### PR TITLE
[강의리마인더] 시간이 존재하지 않는 경우 에러메시지 변경

### DIFF
--- a/core/src/main/kotlin/common/exception/ErrorType.kt
+++ b/core/src/main/kotlin/common/exception/ErrorType.kt
@@ -64,6 +64,7 @@ enum class ErrorType(
     UPDATE_APP_VERSION(HttpStatus.BAD_REQUEST, 40021, "앱 버전을 업데이트해주세요", "앱 버전을 업데이트해주세요"),
     NOT_PUBLISHED_THEME(HttpStatus.BAD_REQUEST, 40022, "공유한 테마가 아닙니다", "공유한 테마가 아닙니다"),
     PUBLISHED_THEME_DELETE_ERROR(HttpStatus.BAD_REQUEST, 40023, "테마마켓에서 테마를 내린 뒤 다시 시도해주세요", "테마마켓에서 테마를 내린 뒤 다시 시도해주세요"),
+    TIMETABLE_LECTURE_REMINDER_INVALID_TIME(HttpStatus.BAD_REQUEST, 40024, "리마인더는 시간이 설정된 강의에만 등록할 수 있어요", "리마인더는 시간이 설정된 강의에만 등록할 수 있어요"),
 
     SOCIAL_CONNECT_FAIL(HttpStatus.UNAUTHORIZED, 40100, "소셜 로그인에 실패했습니다", "소셜 로그인에 실패했습니다"),
     INVALID_APPLE_LOGIN_TOKEN(HttpStatus.UNAUTHORIZED, 40101, "유효하지 않은 애플 로그인 토큰입니다", "소셜 로그인에 실패했습니다"),

--- a/core/src/main/kotlin/common/exception/SnuttException.kt
+++ b/core/src/main/kotlin/common/exception/SnuttException.kt
@@ -93,6 +93,8 @@ object NotPublishedThemeException : SnuttException(ErrorType.NOT_PUBLISHED_THEME
 
 object PublishedThemeDeleteErrorException : SnuttException(ErrorType.PUBLISHED_THEME_DELETE_ERROR)
 
+object TimetableLectureReminderInvalidTimeException : SnuttException(ErrorType.TIMETABLE_LECTURE_REMINDER_INVALID_TIME)
+
 object SocialConnectFailException : SnuttException(ErrorType.SOCIAL_CONNECT_FAIL)
 
 object InvalidAppleLoginTokenException : SnuttException(ErrorType.INVALID_APPLE_LOGIN_TOKEN)

--- a/core/src/main/kotlin/timetablelecturereminder/service/TimetableLectureReminderService.kt
+++ b/core/src/main/kotlin/timetablelecturereminder/service/TimetableLectureReminderService.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.snutt.timetablelecturereminder.service
 
-import com.wafflestudio.snutt.common.exception.InvalidTimeException
 import com.wafflestudio.snutt.common.exception.TimetableLectureNotFoundException
+import com.wafflestudio.snutt.common.exception.TimetableLectureReminderInvalidTimeException
 import com.wafflestudio.snutt.common.exception.TimetableNotFoundException
 import com.wafflestudio.snutt.timetablelecturereminder.data.TimetableLectureAndReminder
 import com.wafflestudio.snutt.timetablelecturereminder.data.TimetableLectureReminder
@@ -70,7 +70,7 @@ class TimetableLectureReminderServiceImpl(
         val timetableLecture =
             timetable.lectures.find { it.id == timetableLectureId } ?: throw TimetableLectureNotFoundException
 
-        if (timetableLecture.classPlaceAndTimes.isEmpty()) throw InvalidTimeException
+        if (timetableLecture.classPlaceAndTimes.isEmpty()) throw TimetableLectureReminderInvalidTimeException
 
         // '없음' 옵션인 경우 기존 리마인더 삭제
         if (option == TimetableLectureReminderOption.NONE) {


### PR DESCRIPTION
## 변경사항
- 시간이 존재하지 않는 강의에 리마인더를 등록하려고 할 때 에러메시지를 친절하게 바꾸었습니다
- [슬랙](https://wafflestudio.slack.com/archives/C0PAVPS5T/p1760455425894189?thread_ts=1757153125.685969&cid=C0PAVPS5T)