### PR TITLE
[강의리마인더] 00:00에 알림 보내지 못하는 이슈 수정

### DIFF
--- a/core/src/main/kotlin/timetablelecturereminder/repository/TimetableLectureReminderCustomRepository.kt
+++ b/core/src/main/kotlin/timetablelecturereminder/repository/TimetableLectureReminderCustomRepository.kt
@@ -7,7 +7,7 @@ import org.springframework.data.mongodb.core.find
 import org.springframework.data.mongodb.core.query.Criteria
 import org.springframework.data.mongodb.core.query.Query
 import org.springframework.data.mongodb.core.query.elemMatch
-import org.springframework.data.mongodb.core.query.gt
+import org.springframework.data.mongodb.core.query.gte
 import org.springframework.data.mongodb.core.query.isEqualTo
 import org.springframework.data.mongodb.core.query.lt
 import org.springframework.data.mongodb.core.query.lte
@@ -36,7 +36,7 @@ class TimetableLectureReminderCustomRepositoryImpl(
                 Criteria().andOperator(
                     TimetableLectureReminder.Schedule::day isEqualTo dayOfWeek,
                     Criteria().andOperator(
-                        TimetableLectureReminder.Schedule::minute gt startMinute,
+                        TimetableLectureReminder.Schedule::minute gte startMinute,
                         TimetableLectureReminder.Schedule::minute lte endMinute,
                     ),
                     Criteria().orOperator(

--- a/core/src/main/kotlin/timetablelecturereminder/service/TimetableLectureReminderNotifierService.kt
+++ b/core/src/main/kotlin/timetablelecturereminder/service/TimetableLectureReminderNotifierService.kt
@@ -67,7 +67,8 @@ class TimetableLectureReminderNotifierServiceImpl(
     private suspend fun getTargetReminders(currentTime: Instant): List<TimetableLectureReminder> {
         val endSchedule = TimetableLectureReminder.Schedule.fromInstant(currentTime)
         val startSchedule = endSchedule.minusMinutes(REMINDER_TIME_WINDOW_MINUTES.toInt())
-        val lastNotifiedBefore = currentTime.minus(REMINDER_TIME_WINDOW_MINUTES, ChronoUnit.MINUTES)
+        // 10분 전에 알림 보내놓고 다시 보내는 경우를 막기 위해 버퍼로 1분을 더한다.
+        val lastNotifiedBefore = currentTime.minus(REMINDER_TIME_WINDOW_MINUTES + 1, ChronoUnit.MINUTES)
 
         val reminders =
             if (startSchedule.day == endSchedule.day) {


### PR DESCRIPTION
## 문제상황
- #390 에서 여기에서 10분 간격으로 중복 보내는 현상을 막기 위해 검색 범위를 (-10분전, 현재]로 했더니, 00:00에 대상 리마인더를 조회하지 못하는 문제가 발생
  - 전날 (23:50, 23:59], 오늘 (00:00, 00:01] 범위로 조회해서, 00:00에 등록된 리마인더는 조회되지 않음
## 해결
- [-10분전, 현재] 로 조회 범위 수정
- 대신, 중복 발송을 피하기 위해 lastNotifiedBefore를 1분 빼서 여유있게 조회함