### PR TITLE
FCM message type 구분하기

### DIFF
--- a/core/src/main/kotlin/common/push/dto/PushMessages.kt
+++ b/core/src/main/kotlin/common/push/dto/PushMessages.kt
@@ -39,7 +39,8 @@ data class PushMessage(
     val isUrgentOnAndroid: Boolean = false,
     /**
      * true라면 data message로 보내고, false라면 notification message로 보낸다.
-     * data message는 클라이언트에서 직접
+     *
+     * notification message는 안드로이드 앱이 백그라운드에 있을 때 알림 배너가 제대로 노출되지 않으므로, 궁극적으로는 data message로 모두 바꿔야 한다.
      * @see [Firebase 문서](https://firebase.google.com/docs/cloud-messaging/customize-messages/set-message-type)
      */
     val shouldSendAsDataMessage: Boolean = false,

--- a/core/src/main/kotlin/common/push/dto/PushMessages.kt
+++ b/core/src/main/kotlin/common/push/dto/PushMessages.kt
@@ -32,7 +32,17 @@ data class PushMessage(
     val body: String,
     val urlScheme: Deeplink? = null,
     val data: Data = Data(emptyMap()),
-    val isUrgentOnAndroid: Boolean = false, // true라면 안드로이드 doze 모드(배터리 절약 모드) 중에 기기를 깨우고 정확한 알림을 보낸다
+    /**
+     * true라면 안드로이드 doze 모드(배터리 절약 모드) 중에
+     * 기기를 깨우고 정확한 알림을 보낸다
+     */
+    val isUrgentOnAndroid: Boolean = false,
+    /**
+     * true라면 data message로 보내고, false라면 notification message로 보낸다.
+     * data message는 클라이언트에서 직접
+     * @see [Firebase 문서](https://firebase.google.com/docs/cloud-messaging/customize-messages/set-message-type)
+     */
+    val shouldSendAsDataMessage: Boolean = false,
 ) {
     data class Data(
         val payload: Map<String, String>,

--- a/core/src/main/kotlin/common/push/fcm/FcmPushClient.kt
+++ b/core/src/main/kotlin/common/push/fcm/FcmPushClient.kt
@@ -27,6 +27,8 @@ internal class FcmPushClient(
     @Value("\${google.firebase.service-account}") private val serviceAccountString: String,
 ) : PushClient {
     private object PayloadKeys {
+        const val TITLE = "title"
+        const val BODY = "body"
         const val URL_SCHEME = "url_scheme"
     }
 
@@ -118,7 +120,12 @@ internal class FcmPushClient(
                 is TargetedPushMessageWithTopic -> setTopic(topic)
             }
             message.urlScheme?.let { putData(PayloadKeys.URL_SCHEME, it.value) }
-            setNotification(notification)
+            if (message.shouldSendAsDataMessage) {
+                putData(PayloadKeys.TITLE, message.title)
+                putData(PayloadKeys.BODY, message.body)
+            } else {
+                setNotification(notification)
+            }
             setAndroidConfig(androidConfig)
             putAllData(message.data.payload)
             build()

--- a/core/src/main/kotlin/timetablelecturereminder/service/TimetableLectureReminderNotifierService.kt
+++ b/core/src/main/kotlin/timetablelecturereminder/service/TimetableLectureReminderNotifierService.kt
@@ -42,7 +42,7 @@ class TimetableLectureReminderNotifierServiceImpl(
         val lockKey = CacheKey.LOCK_SEND_TIMETABLE_LECTURE_REMINDER_NOTIFICATION.build()
         cache.withLock(lockKey) {
             try {
-                logger.debug("강의 리마인더 알림 전송 작업을 시작합니다.")
+                logger.info("강의 리마인더 알림 전송 작업을 시작합니다.")
                 val currentTime = Instant.now()
                 val (currentYear, currentSemester) =
                     semesterService.getCurrentYearAndSemester(currentTime) ?: run {
@@ -222,6 +222,7 @@ class TimetableLectureReminderNotifierServiceImpl(
             title = pushTitle,
             body = pushBody,
             isUrgentOnAndroid = true,
+            shouldSendAsDataMessage = true,
         )
     }
 }


### PR DESCRIPTION
## 배경
- 아래의 '클라이언트'는 안드로이드임. iOS는 동작 확인 필요
- FCM의 메시지의 페이로드는 `notification`과 `data`라는 2개 필드를 가진다. 이 필드의 유무에 따라 2개 타입으로 나뉜다.
  - Data message: data 필드만 존재
    - data는 개발자가 풀로 커스텀하는 key value map
    - 클라이언트에서 직접 코드 짜서 알림 띄워야함
  - Notification message: notification 필드만 존재 or notification과 data 모두 존재
    - notification은 title, body 등 기본적인 정보를 가짐
    - 클라이언트에서 아무 코드 짜지 않아도 FCM SDK가 자동으로 알림 띄워줌
- [문서](https://firebase.google.com/docs/cloud-messaging/customize-messages/set-message-type?_gl=1*hd1ams*_up*MQ..*_ga*ODEyMjczMjEwLjE3NjE3NDI5MDQ.*_ga_CW55HF8NVT*czE3NjE3NDI5MDQkbzEkZzAkdDE3NjE3NDI5MDQkajYwJGwwJGgw)
- 우리 서버는 notification message만 보내고 있고(FcmPushClient 참고), 우리 안드로이드는 별도 코드 없이 FCM SDK만 붙여놨음(=data message 대응이 되어있지 않음)
## 문제
- 안드로이드 앱이 백그라운드에 있을 때, 알림 배너가 뜨지 않고 작업표시줄에 조용히 추가만 됨([영상](https://wafflestudio.slack.com/archives/C0PAVPS5T/p1761466715506689?thread_ts=1761399143.904439&cid=C0PAVPS5T))
- 안드로이드 앱이 포그라운드에 있을 때엔, 알림이 전혀 뜨지 않음
- => 강의 리마인더, 빈자리 알림처럼 유저가 꼭 인지해야 하는 알림을 인지하기 어려움
- FCM SDK만 붙여놨기 때문임([문서](https://firebase.google.com/docs/cloud-messaging/receive-messages?platform=android))
## 해결
- 서버) 점진적으로 data message로 바꾸기
  - 마음같아선 지금 전부 data message로 바꾸고 싶지만, 그러면 안드 구버전 클라가 푸시를 절대 받을 수 없음
  - 그래서 이번에 새로 나가는 강의 리마인더만 data message로 보내고, 나머지는 notification message로 보내도록 했습니다
- 안드) 알림 직접 띄우는 코드 추가
- iOS) data message 받았을 때 정상 동작하는지 확인 중