### PR TITLE
FCM ApnsConfig 추가

### DIFF
--- a/core/src/main/resources/application-common.yml
+++ b/core/src/main/resources/application-common.yml
@@ -15,6 +15,8 @@ google:
     project-id:
     service-account:
     api-key:
+    ios:
+      bundle-id:
     dynamic-link:
       domain-uri-prefix:
       link-prefix:
@@ -69,6 +71,8 @@ google:
     project-id:
     service-account:
     api-key:
+    ios:
+      bundle-id:
     dynamic-link:
       domain-uri-prefix:
       link-prefix:
@@ -106,6 +110,8 @@ google:
     project-id:
     service-account:
     api-key:
+    ios:
+      bundle-id:
     dynamic-link:
       domain-uri-prefix:
       link-prefix:

--- a/core/src/testFixtures/resources/application.yaml
+++ b/core/src/testFixtures/resources/application.yaml
@@ -12,6 +12,8 @@ google:
     project-id:
     service-account:
     api-key:
+    ios:
+      bundle-id:
     dynamic-link:
       domain-uri-prefix:
       link-prefix: "https://snutt.page.link"


### PR DESCRIPTION
## Goal
- iOS도 백그라운드에서 data message를 받을 수 있도록 ApnsConfig를 추가해서 보냅니다.

## 문제 상황
- #412 에서 강의리마인더 푸시를 FCM data message로 보내도록 변경했고, iOS가 백그라운드에서 data message를 받지 못하는 문제가 생겼습니다.

## 해결 방법
- 백그라운드에서 푸시 받을 수 있도록 ApnsConfig를 추가합니다.
- OS 구분은 하지 않고 AndroidConfig와 ApnsConfig 모두 보냅니다.
- ApnsConfig에 ios bundle id가 필요하여 property로 추가했습니다. secrets manager에도 올려놓을 예정