### PR TITLE
빈자리알림 신규 등록 시 에러 내려주기

### DIFF
--- a/core/src/main/kotlin/common/exception/ErrorType.kt
+++ b/core/src/main/kotlin/common/exception/ErrorType.kt
@@ -65,7 +65,12 @@ enum class ErrorType(
     NOT_PUBLISHED_THEME(HttpStatus.BAD_REQUEST, 40022, "공유한 테마가 아닙니다", "공유한 테마가 아닙니다"),
     PUBLISHED_THEME_DELETE_ERROR(HttpStatus.BAD_REQUEST, 40023, "테마마켓에서 테마를 내린 뒤 다시 시도해주세요", "테마마켓에서 테마를 내린 뒤 다시 시도해주세요"),
     TIMETABLE_LECTURE_REMINDER_INVALID_TIME(HttpStatus.BAD_REQUEST, 40024, "리마인더는 시간이 설정된 강의에만 등록할 수 있어요", "리마인더는 시간이 설정된 강의에만 등록할 수 있어요"),
-    VACANCY_NOTIFICATION_TEMPORARILY_UNAVAILABLE(HttpStatus.BAD_REQUEST, 40025, "빈자리 알림은 현재 일시 중단되었습니다. 자세한 내용은 알림을 참고해 주세요.", "빈자리 알림은 현재 일시 중단되었습니다. 자세한 내용은 알림을 참고해 주세요.",),
+    VACANCY_NOTIFICATION_TEMPORARILY_UNAVAILABLE(
+        HttpStatus.BAD_REQUEST,
+        40025,
+        "빈자리 알림은 현재 일시 중단되었습니다. 자세한 내용은 알림을 참고해 주세요.",
+        "빈자리 알림은 현재 일시 중단되었습니다. 자세한 내용은 알림을 참고해 주세요.",
+    ),
 
     SOCIAL_CONNECT_FAIL(HttpStatus.UNAUTHORIZED, 40100, "소셜 로그인에 실패했습니다", "소셜 로그인에 실패했습니다"),
     INVALID_APPLE_LOGIN_TOKEN(HttpStatus.UNAUTHORIZED, 40101, "유효하지 않은 애플 로그인 토큰입니다", "소셜 로그인에 실패했습니다"),

--- a/core/src/main/kotlin/common/exception/ErrorType.kt
+++ b/core/src/main/kotlin/common/exception/ErrorType.kt
@@ -65,6 +65,12 @@ enum class ErrorType(
     NOT_PUBLISHED_THEME(HttpStatus.BAD_REQUEST, 40022, "공유한 테마가 아닙니다", "공유한 테마가 아닙니다"),
     PUBLISHED_THEME_DELETE_ERROR(HttpStatus.BAD_REQUEST, 40023, "테마마켓에서 테마를 내린 뒤 다시 시도해주세요", "테마마켓에서 테마를 내린 뒤 다시 시도해주세요"),
     TIMETABLE_LECTURE_REMINDER_INVALID_TIME(HttpStatus.BAD_REQUEST, 40024, "리마인더는 시간이 설정된 강의에만 등록할 수 있어요", "리마인더는 시간이 설정된 강의에만 등록할 수 있어요"),
+    VACANCY_NOTIFICATION_TEMPORARILY_UNAVAILABLE(
+        HttpStatus.BAD_REQUEST,
+        40025,
+        "빈자리 알림은 현재 일시 중단되었습니다. 자세한 내용은 알림을 참고해 주세요.",
+        "빈자리 알림은 현재 일시 중단되었습니다. 자세한 내용은 알림을 참고해 주세요.",
+    ),
 
     SOCIAL_CONNECT_FAIL(HttpStatus.UNAUTHORIZED, 40100, "소셜 로그인에 실패했습니다", "소셜 로그인에 실패했습니다"),
     INVALID_APPLE_LOGIN_TOKEN(HttpStatus.UNAUTHORIZED, 40101, "유효하지 않은 애플 로그인 토큰입니다", "소셜 로그인에 실패했습니다"),

--- a/core/src/main/kotlin/common/exception/ErrorType.kt
+++ b/core/src/main/kotlin/common/exception/ErrorType.kt
@@ -65,12 +65,7 @@ enum class ErrorType(
     NOT_PUBLISHED_THEME(HttpStatus.BAD_REQUEST, 40022, "공유한 테마가 아닙니다", "공유한 테마가 아닙니다"),
     PUBLISHED_THEME_DELETE_ERROR(HttpStatus.BAD_REQUEST, 40023, "테마마켓에서 테마를 내린 뒤 다시 시도해주세요", "테마마켓에서 테마를 내린 뒤 다시 시도해주세요"),
     TIMETABLE_LECTURE_REMINDER_INVALID_TIME(HttpStatus.BAD_REQUEST, 40024, "리마인더는 시간이 설정된 강의에만 등록할 수 있어요", "리마인더는 시간이 설정된 강의에만 등록할 수 있어요"),
-    VACANCY_NOTIFICATION_TEMPORARILY_UNAVAILABLE(
-        HttpStatus.BAD_REQUEST,
-        40025,
-        "빈자리 알림은 현재 일시 중단되었습니다. 자세한 내용은 알림을 참고해 주세요.",
-        "빈자리 알림은 현재 일시 중단되었습니다. 자세한 내용은 알림을 참고해 주세요.",
-    ),
+    VACANCY_NOTIFICATION_TEMPORARILY_UNAVAILABLE(HttpStatus.BAD_REQUEST, 40025, "빈자리 알림은 현재 일시 중단되었습니다. 자세한 내용은 알림을 참고해 주세요.", "빈자리 알림은 현재 일시 중단되었습니다. 자세한 내용은 알림을 참고해 주세요.",),
 
     SOCIAL_CONNECT_FAIL(HttpStatus.UNAUTHORIZED, 40100, "소셜 로그인에 실패했습니다", "소셜 로그인에 실패했습니다"),
     INVALID_APPLE_LOGIN_TOKEN(HttpStatus.UNAUTHORIZED, 40101, "유효하지 않은 애플 로그인 토큰입니다", "소셜 로그인에 실패했습니다"),

--- a/core/src/main/kotlin/common/exception/SnuttException.kt
+++ b/core/src/main/kotlin/common/exception/SnuttException.kt
@@ -95,6 +95,8 @@ object PublishedThemeDeleteErrorException : SnuttException(ErrorType.PUBLISHED_T
 
 object TimetableLectureReminderInvalidTimeException : SnuttException(ErrorType.TIMETABLE_LECTURE_REMINDER_INVALID_TIME)
 
+object VacancyNotificationTemporarilyUnavailableException : SnuttException(ErrorType.VACANCY_NOTIFICATION_TEMPORARILY_UNAVAILABLE)
+
 object SocialConnectFailException : SnuttException(ErrorType.SOCIAL_CONNECT_FAIL)
 
 object InvalidAppleLoginTokenException : SnuttException(ErrorType.INVALID_APPLE_LOGIN_TOKEN)

--- a/core/src/main/kotlin/vacancynotification/service/VacancyNotificationService.kt
+++ b/core/src/main/kotlin/vacancynotification/service/VacancyNotificationService.kt
@@ -1,15 +1,12 @@
 package com.wafflestudio.snutt.vacancynotification.service
 
 import com.wafflestudio.snutt.common.exception.DuplicateVacancyNotificationException
-import com.wafflestudio.snutt.common.exception.InvalidRegistrationForPreviousSemesterCourseException
-import com.wafflestudio.snutt.common.exception.LectureNotFoundException
+import com.wafflestudio.snutt.common.exception.VacancyNotificationTemporarilyUnavailableException
 import com.wafflestudio.snutt.coursebook.service.CoursebookService
 import com.wafflestudio.snutt.lectures.data.Lecture
 import com.wafflestudio.snutt.lectures.repository.LectureRepository
 import com.wafflestudio.snutt.vacancynotification.data.VacancyNotification
 import com.wafflestudio.snutt.vacancynotification.repository.VacancyNotificationRepository
-import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
 import org.springframework.dao.DuplicateKeyException
@@ -57,19 +54,9 @@ class VacancyNotificationServiceImpl(
     override suspend fun addVacancyNotification(
         userId: String,
         lectureId: String,
-    ): VacancyNotification =
-        coroutineScope {
-            val deferredLecture = async { lectureRepository.findById(lectureId) }
-            val deferredLatestCoursebook = async { coursebookService.getLatestCoursebook() }
-            val (lecture, latestCoursebook) = deferredLecture.await() to deferredLatestCoursebook.await()
-
-            if (lecture == null) throw LectureNotFoundException
-            if (!(lecture.year == latestCoursebook.year && lecture.semester == latestCoursebook.semester)) {
-                throw InvalidRegistrationForPreviousSemesterCourseException
-            }
-
-            trySave(VacancyNotification(userId = userId, lectureId = lectureId))
-        }
+    ): VacancyNotification {
+        throw VacancyNotificationTemporarilyUnavailableException // 2025-11-06 정보화본부 취소여석 정책이 바뀜에 따라 빈자리알림을 대응 전까지 일시 중단한다
+    }
 
     override suspend fun deleteVacancyNotification(
         userId: String,


### PR DESCRIPTION
## 변경사항
- 정보화본부 취소여석 정책이 바뀜에 따라 빈자리알림이  기대 동작을 하지 않는 중 + ip밴 먹은 듯
- 유저에게 공지를 위해, 빈자리알림 신규 등록 시 에러를 내려줍니다. + 푸시도 보낼 예정