### PR TITLE
취소여석 여부를 사이트에서 파싱해서 가져오기

### DIFF
--- a/batch/src/main/kotlin/sugangsnu/job/vacancynotification/data/RegistrationStatus.kt
+++ b/batch/src/main/kotlin/sugangsnu/job/vacancynotification/data/RegistrationStatus.kt
@@ -4,4 +4,5 @@ data class RegistrationStatus(
     val courseNumber: String,
     val lectureNumber: String,
     val registrationCount: Int,
+    val remainingPlace: Boolean,
 )

--- a/batch/src/main/kotlin/sugangsnu/job/vacancynotification/data/RegistrationStatus.kt
+++ b/batch/src/main/kotlin/sugangsnu/job/vacancynotification/data/RegistrationStatus.kt
@@ -4,5 +4,5 @@ data class RegistrationStatus(
     val courseNumber: String,
     val lectureNumber: String,
     val registrationCount: Int,
-    val remainingPlace: Boolean,
+    val wasFull: Boolean,
 )

--- a/batch/src/main/kotlin/sugangsnu/job/vacancynotification/service/VacancyNotifierService.kt
+++ b/batch/src/main/kotlin/sugangsnu/job/vacancynotification/service/VacancyNotifierService.kt
@@ -93,7 +93,7 @@ class VacancyNotifierServiceImpl(
                     .map { (lecture, status) ->
                         lecture.apply {
                             registrationCount = status.registrationCount
-                            wasFull = wasFull || lecture.isFull()
+                            wasFull = status.remainingPlace
                         }
                     }
             lectureService.upsertLectures(updated)
@@ -178,10 +178,16 @@ class VacancyNotifierServiceImpl(
                                 .split("/")
                                 .first()
                                 .toInt()
+                        val remainingPlace =
+                            info
+                                .select("li.state > span[data-dialog-target='remaining-place-dialog']")
+                                .isNotEmpty()
+
                         RegistrationStatus(
                             courseNumber = courseNumber,
                             lectureNumber = lectureNumber,
                             registrationCount = registrationCount,
+                            remainingPlace = remainingPlace,
                         )
                     }
             }

--- a/batch/src/main/kotlin/sugangsnu/job/vacancynotification/service/VacancyNotifierService.kt
+++ b/batch/src/main/kotlin/sugangsnu/job/vacancynotification/service/VacancyNotifierService.kt
@@ -93,7 +93,7 @@ class VacancyNotifierServiceImpl(
                     .map { (lecture, status) ->
                         lecture.apply {
                             registrationCount = status.registrationCount
-                            wasFull = status.remainingPlace
+                            wasFull = status.wasFull
                         }
                     }
             lectureService.upsertLectures(updated)
@@ -178,7 +178,7 @@ class VacancyNotifierServiceImpl(
                                 .split("/")
                                 .first()
                                 .toInt()
-                        val remainingPlace =
+                        val wasFull =
                             info
                                 .select("li.state > span[data-dialog-target='remaining-place-dialog']")
                                 .isNotEmpty()
@@ -187,7 +187,7 @@ class VacancyNotifierServiceImpl(
                             courseNumber = courseNumber,
                             lectureNumber = lectureNumber,
                             registrationCount = registrationCount,
-                            remainingPlace = remainingPlace,
+                            wasFull = wasFull,
                         )
                     }
             }


### PR DESCRIPTION
원래는 우리가 크롤링한 정보에서 수강생이 꽉 찼던 기록이 있고, 현재 다 차있지 않으면 취소여석이라고 띄웠는데
이게 실제 수강신청 사이트랑 표시가 다른 문제가 있었어요
직접 파싱해오는 방법으로 바꿨습니다

사이트에서 비슷한 방법으로 영어강의, 크로스리스팅 등등 동그란 배지 뜨는것도 알아낼수 있을듯?

bool인데 remaining place라고 되어있는건 수강스누에서 쓰는 말 그대로 가져온건데 좀 부자연스러운거 같기도 해요