### PR TITLE
insert_noti로 FCM data message 보낼 수 있게 하기

### DIFF
--- a/api/src/main/kotlin/router/docs/AdminDocs.kt
+++ b/api/src/main/kotlin/router/docs/AdminDocs.kt
@@ -42,9 +42,16 @@ import org.springframework.web.bind.annotation.RequestMethod
                             ),
                         ],
                         required = true,
-                        description = "userId == null이면 모든 유저에게 보냄\ninsertFcm == true && shouldSendAsDataMessage == true이면 FCM data message(클라에서 직접 대응 필요한 메시지)로 푸시 보냄",
+                        description =
+                            "userId == null이면 모든 유저에게 보냄\n" +
+                                "insertFcm == true && shouldSendAsDataMessage == true이면 FCM data message(클라에서 직접 대응 필요한 메시지)로 보냄",
                     ),
-                responses = [ApiResponse(responseCode = "200", content = [Content(schema = Schema(implementation = OkResponse::class))])],
+                responses = [
+                    ApiResponse(
+                        responseCode = "200",
+                        content = [Content(schema = Schema(implementation = OkResponse::class))],
+                    ),
+                ],
             ),
     ),
     RouterOperation(
@@ -233,7 +240,12 @@ import org.springframework.web.bind.annotation.RequestMethod
                 parameters = [
                     Parameter(`in` = ParameterIn.QUERY, name = "name", required = true),
                 ],
-                responses = [ApiResponse(responseCode = "200", content = [Content(schema = Schema(implementation = OkResponse::class))])],
+                responses = [
+                    ApiResponse(
+                        responseCode = "200",
+                        content = [Content(schema = Schema(implementation = OkResponse::class))],
+                    ),
+                ],
             ),
     ),
     RouterOperation(
@@ -246,7 +258,12 @@ import org.springframework.web.bind.annotation.RequestMethod
                 parameters = [
                     Parameter(`in` = ParameterIn.QUERY, name = "name", required = true),
                 ],
-                responses = [ApiResponse(responseCode = "200", content = [Content(schema = Schema(implementation = OkResponse::class))])],
+                responses = [
+                    ApiResponse(
+                        responseCode = "200",
+                        content = [Content(schema = Schema(implementation = OkResponse::class))],
+                    ),
+                ],
             ),
     ),
     RouterOperation(
@@ -266,7 +283,12 @@ import org.springframework.web.bind.annotation.RequestMethod
                         ],
                         required = true,
                     ),
-                responses = [ApiResponse(responseCode = "200", content = [Content(schema = Schema(implementation = OkResponse::class))])],
+                responses = [
+                    ApiResponse(
+                        responseCode = "200",
+                        content = [Content(schema = Schema(implementation = OkResponse::class))],
+                    ),
+                ],
             ),
     ),
     RouterOperation(
@@ -279,7 +301,12 @@ import org.springframework.web.bind.annotation.RequestMethod
                 parameters = [
                     Parameter(`in` = ParameterIn.PATH, name = "id", required = true),
                 ],
-                responses = [ApiResponse(responseCode = "200", content = [Content(schema = Schema(implementation = OkResponse::class))])],
+                responses = [
+                    ApiResponse(
+                        responseCode = "200",
+                        content = [Content(schema = Schema(implementation = OkResponse::class))],
+                    ),
+                ],
             ),
     ),
 )

--- a/api/src/main/kotlin/router/docs/AdminDocs.kt
+++ b/api/src/main/kotlin/router/docs/AdminDocs.kt
@@ -42,7 +42,7 @@ import org.springframework.web.bind.annotation.RequestMethod
                             ),
                         ],
                         required = true,
-                        description = "userId null이면 모든 유저에게 보냄",
+                        description = "userId == null이면 모든 유저에게 보냄\ninsertFcm == true && shouldSendAsDataMessage == true이면 FCM data message(클라에서 직접 대응 필요한 메시지)로 푸시 보냄",
                     ),
                 responses = [ApiResponse(responseCode = "200", content = [Content(schema = Schema(implementation = OkResponse::class))])],
             ),

--- a/core/src/main/kotlin/notification/dto/InsertNotificationRequest.kt
+++ b/core/src/main/kotlin/notification/dto/InsertNotificationRequest.kt
@@ -10,6 +10,7 @@ data class InsertNotificationRequest(
     val title: String,
     val body: String,
     val insertFcm: Boolean,
+    val shouldSendAsDataMessage: Boolean,
     val type: NotificationType = NotificationType.NORMAL,
     val dataPayload: Map<String, String> = emptyMap(),
 )

--- a/core/src/main/kotlin/notification/service/NotificationAdminService.kt
+++ b/core/src/main/kotlin/notification/service/NotificationAdminService.kt
@@ -23,7 +23,7 @@ class NotificationAdminService(
                 title = request.title,
                 body = request.body,
                 data = PushMessage.Data(request.dataPayload),
-                shouldSendAsDataMessage = true,
+                shouldSendAsDataMessage = request.shouldSendAsDataMessage,
             )
         val notificationType = request.type
 

--- a/core/src/main/kotlin/notification/service/NotificationAdminService.kt
+++ b/core/src/main/kotlin/notification/service/NotificationAdminService.kt
@@ -20,9 +20,10 @@ class NotificationAdminService(
 
         val pushMessage =
             PushMessage(
-                request.title,
-                request.body,
-                request.dataPayload,
+                title = request.title,
+                body = request.body,
+                data = PushMessage.Data(request.dataPayload),
+                shouldSendAsDataMessage = true,
             )
         val notificationType = request.type
 


### PR DESCRIPTION
## Goal
- 클라에서 data message 테스트를 쉽게 하기 위해, `POST /admin/insert_noti`에 data message로 보내는 기능을 추가했습니다.

## 변경사항
- 클라 개발을 하면서 data message를 테스트해야 하는 일이 생겼음
- data message는 하위호환 때문에 현재 강의리마인더에만 적용되어 있음. 나머지는 모두 notification message인 상태.
- 클라에서 테스트할 목적으로 쓰는 `POST /admin/insert_noti` 도 notification message임.
- 그래서 해당 API에 data message로 보내는 필드를 추가함.