### PR TITLE
빈자리알림 알림 보내지 않기 (테스트용)

### DIFF
--- a/batch/src/main/kotlin/sugangsnu/job/vacancynotification/service/VacancyNotifierService.kt
+++ b/batch/src/main/kotlin/sugangsnu/job/vacancynotification/service/VacancyNotifierService.kt
@@ -6,7 +6,6 @@ import com.wafflestudio.snutt.common.push.dto.PushMessage
 import com.wafflestudio.snutt.coursebook.data.Coursebook
 import com.wafflestudio.snutt.lectures.data.Lecture
 import com.wafflestudio.snutt.lectures.service.LectureService
-import com.wafflestudio.snutt.notification.data.NotificationType
 import com.wafflestudio.snutt.notification.service.PushWithNotificationService
 import com.wafflestudio.snutt.sugangsnu.common.SugangSnuRepository
 import com.wafflestudio.snutt.sugangsnu.job.vacancynotification.data.RegistrationStatus
@@ -116,11 +115,13 @@ class VacancyNotifierServiceImpl(
                                 urlScheme = DeeplinkType.VACANCY.build(),
                                 isUrgentOnAndroid = true,
                             )
+                        /*
                         pushWithNotificationService.sendPushesAndNotifications(
                             pushMessage,
                             NotificationType.LECTURE_VACANCY,
                             userIds,
                         )
+                         */
                     }
                 }
             }


### PR DESCRIPTION
prod에서 알림 보내지 않고 크롤링만 테스트해볼 목적으로 임시로 수정했어요
수강신청 제도가 바뀐거라 아마 원래 상태로 다시 돌아올 일은 없을듯