### PR TITLE
[강의 리마인더] 스웨거 수정

### DIFF
--- a/api/src/main/kotlin/router/docs/TimetableDocs.kt
+++ b/api/src/main/kotlin/router/docs/TimetableDocs.kt
@@ -451,6 +451,7 @@ import timetables.dto.TimetableBriefDto
                         content = [
                             Content(
                                 schema = Schema(implementation = TimetableLectureReminderModifyRequestDto::class),
+                                mediaType = MediaType.APPLICATION_JSON_VALUE,
                             ),
                         ],
                     ),


### PR DESCRIPTION
## 변경사항
- 스웨거에서 PUT reminder 의 request body의 media type이 지정되지 않아서 application/json이 아니라 */*으로 보이고 있었음
- 그래서 media type을 명시