### PR TITLE
FCM payload에 ApnsAlert 추가

### DIFF
--- a/core/src/main/kotlin/common/push/fcm/FcmPushClient.kt
+++ b/core/src/main/kotlin/common/push/fcm/FcmPushClient.kt
@@ -106,12 +106,6 @@ internal class FcmPushClient(
     }
 
     private fun TargetedPushMessage.toFcmMessage(): Message {
-        val notification =
-            Notification
-                .builder()
-                .setTitle(message.title)
-                .setBody(message.body)
-                .build()
         val androidConfig =
             AndroidConfig
                 .builder()
@@ -146,7 +140,13 @@ internal class FcmPushClient(
                 putData(PayloadKeys.TITLE, message.title)
                 putData(PayloadKeys.BODY, message.body)
             } else {
-                setNotification(notification) // 추후 클리닝할 분기
+                setNotification(
+                    Notification
+                        .builder()
+                        .setTitle(message.title)
+                        .setBody(message.body)
+                        .build(),
+                ) // 추후 클리닝할 분기
             }
             setAndroidConfig(androidConfig)
             setApnsConfig(apnsConfig)

--- a/core/src/main/kotlin/common/push/fcm/FcmPushClient.kt
+++ b/core/src/main/kotlin/common/push/fcm/FcmPushClient.kt
@@ -6,6 +6,7 @@ import com.google.firebase.FirebaseOptions
 import com.google.firebase.messaging.AndroidConfig
 import com.google.firebase.messaging.ApnsConfig
 import com.google.firebase.messaging.Aps
+import com.google.firebase.messaging.ApsAlert
 import com.google.firebase.messaging.FirebaseMessaging
 import com.google.firebase.messaging.Message
 import com.google.firebase.messaging.Notification
@@ -120,13 +121,19 @@ internal class FcmPushClient(
         val apnsConfig =
             ApnsConfig
                 .builder()
-                .putHeader("apns-push-type", "background")
+                .putHeader("apns-push-type", "alert")
                 .putHeader("apns-priority", "5")
                 .putHeader("apns-topic", iosBundleId)
                 .setAps(
                     Aps
                         .builder()
-                        .setContentAvailable(true)
+                        .setAlert(
+                            ApsAlert
+                                .builder()
+                                .setTitle(message.title)
+                                .setBody(message.body)
+                                .build(),
+                        ).setContentAvailable(true)
                         .build(),
                 ).build()
         return Message.builder().run {


### PR DESCRIPTION
# Goal
- iOS가 백그라운드에서 푸시를 잘 받도록 수정

# 변경사항
- payload에 ApnsAlert 를 추가해서 title과 body를 넣어주고, apns-push-type == alert여야 백그라운드에서 푸시 받음이 보장되어서 그렇게 수정