### PR TITLE
spring-boot-starter-actuator로 health check 추가

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
 
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("io.jsonwebtoken:jjwt-api:0.12.6")
     implementation("io.jsonwebtoken:jjwt-impl:0.12.6")
     implementation("io.jsonwebtoken:jjwt-jackson:0.12.6")

--- a/api/src/main/kotlin/filter/HandlerAnnotationResolver.kt
+++ b/api/src/main/kotlin/filter/HandlerAnnotationResolver.kt
@@ -1,6 +1,5 @@
 package com.wafflestudio.snutt.filter
 
-import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.core.annotation.AnnotatedElementUtils
 import org.springframework.stereotype.Component
 import org.springframework.web.method.HandlerMethod
@@ -10,14 +9,13 @@ import reactor.core.publisher.Mono
 
 @Component
 class HandlerAnnotationResolver(
-    @param:Qualifier("requestMappingHandlerMapping")
-    private val handlerMapping: RequestMappingHandlerMapping,
+    private val requestMappingHandlerMapping: RequestMappingHandlerMapping,
 ) {
     fun isFilterTarget(
         exchange: ServerWebExchange,
         annotationType: Class<out Annotation>,
     ): Mono<Boolean> =
-        handlerMapping
+        requestMappingHandlerMapping
             .getHandler(exchange)
             .map { handler ->
                 if (handler is HandlerMethod) {

--- a/api/src/main/kotlin/filter/HandlerAnnotationResolver.kt
+++ b/api/src/main/kotlin/filter/HandlerAnnotationResolver.kt
@@ -1,5 +1,6 @@
 package com.wafflestudio.snutt.filter
 
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.core.annotation.AnnotatedElementUtils
 import org.springframework.stereotype.Component
 import org.springframework.web.method.HandlerMethod
@@ -9,6 +10,7 @@ import reactor.core.publisher.Mono
 
 @Component
 class HandlerAnnotationResolver(
+    @param:Qualifier("requestMappingHandlerMapping")
     private val handlerMapping: RequestMappingHandlerMapping,
 ) {
     fun isFilterTarget(

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -11,16 +11,6 @@ springdoc:
   paths-to-match: /v1/**
   pre-loading-enabled: true
   pre-loading-locales: ko-KR,en-US
-
-management:
-  endpoints:
-    web:
-      base-path: /
-      path-mapping:
-        health: health-check
-  health:
-    defaults:
-      enabled: false
 ---
 spring:
   config:

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -11,6 +11,13 @@ springdoc:
   paths-to-match: /v1/**
   pre-loading-enabled: true
   pre-loading-locales: ko-KR,en-US
+
+management:
+  endpoints:
+    web:
+      base-path: /
+      path-mapping:
+        health: health-check
 ---
 spring:
   config:

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -18,6 +18,9 @@ management:
       base-path: /
       path-mapping:
         health: health-check
+  health:
+    defaults:
+      enabled: false
 ---
 spring:
   config:


### PR DESCRIPTION
router에서 controller로 바꾸면서 /health-check 가 사라졌는데, 그냥 controller 하나 추가해서 고치려다가 health check를 할때  spring-boot-starter-actuator를 쓴다고 해서 설정해봤어요
원래는 실행 되고 있으면 그냥 200 주는건데 지금 설정상으로는 redis나 db 연결도 체크해서 안되는 상태면 503 주고 있어요
이러면 redis나 db 연결 끊어졌을때 앱을 재시작시킬거 같아서 걱정되는데
이렇게 안하려면  management.health.defaults.enabled = false 로 바꾸면 되고
readiness랑 liveness endporint를 따로 만들어서 k8s에서도 둘을 따로 관리하는게 나으려나?
`@param:Qualifier("requestMappingHandlerMapping")` 이거는 actuator 추가하면서 생기는 에러 해결용이에요