### PR TITLE
PathVariable의 semester도 대응

### DIFF
--- a/core/src/main/kotlin/common/enum/Semester.kt
+++ b/core/src/main/kotlin/common/enum/Semester.kt
@@ -32,6 +32,12 @@ class SemesterReadConverter : Converter<Int, Semester> {
 
 @ReadingConverter
 @Component
+class SemesterStringReadConverter : Converter<String, Semester> {
+    override fun convert(source: String): Semester = Semester.getOfValue(source.toInt())!!
+}
+
+@ReadingConverter
+@Component
 class SemesterNumberReadConverter : Converter<Number, Semester> {
     override fun convert(source: Number): Semester = Semester.getOfValue(source.toInt())!!
 }


### PR DESCRIPTION
```kotlin
    @GetMapping("/{year}/{semester}")
    suspend fun getTagList(
        @PathVariable year: Int,
        @PathVariable semester: Semester,
    ): TagListResponse {
        val tagList = tagService.getTagList(year, semester)
        return TagListResponse(tagList)
    }
```
위와 같은 컨트롤러 메소드에서는 semester가 제대로 변환이 실패했었음
이를 해결하기 위해 string -> semester 컨버터도 추가