### PR TITLE
Oracle GraalVM 및 multi-stage build 사용

### DIFF
--- a/api/Dockerfile-native
+++ b/api/Dockerfile-native
@@ -1,8 +1,13 @@
-FROM ghcr.io/graalvm/native-image-community:25
+# Build stage
+FROM container-registry.oracle.com/graalvm/native-image:25-muslib AS builder
 WORKDIR /app
 ARG CODEARTIFACT_AUTH_TOKEN
 COPY . /app
-RUN microdnf install -y findutils --nodocs
 RUN ./gradlew :api:nativeCompile -PcodeArtifactAuthToken=$CODEARTIFACT_AUTH_TOKEN
+
+# Runtime stage
+FROM scratch
+WORKDIR /app
+COPY --from=builder /app/api/build/native/nativeCompile/api /app/api
 EXPOSE 8080
-ENTRYPOINT api/build/native/nativeCompile/api
+ENTRYPOINT ["/app/api"]

--- a/batch/Dockerfile-native
+++ b/batch/Dockerfile-native
@@ -1,7 +1,13 @@
-FROM ghcr.io/graalvm/jdk-community:25
+# Build stage
+FROM container-registry.oracle.com/graalvm/native-image:25-muslib AS builder
 WORKDIR /app
 ARG CODEARTIFACT_AUTH_TOKEN
 COPY . /app
-RUN microdnf install -y findutils --nodocs
 RUN ./gradlew :batch:nativeCompile -PcodeArtifactAuthToken=$CODEARTIFACT_AUTH_TOKEN
-ENTRYPOINT batch/build/native/nativeCompile/batch --job.name=${JOB_NAME}
+
+# Runtime stage
+FROM scratch
+WORKDIR /app
+COPY --from=builder /app/api/build/native/nativeCompile/batch /app/batch
+EXPOSE 8080
+ENTRYPOINT ["/app/batch", "--job.name=${JOB_NAME}"]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,6 +49,15 @@ subprojects {
     tasks.withType<Test> {
         useJUnitPlatform()
     }
+
+    configure<org.graalvm.buildtools.gradle.dsl.GraalVMExtension> {
+        binaries {
+            named("main") {
+                buildArgs.add("--static")
+                buildArgs.add("--libc=musl")
+            }
+        }
+    }
 }
 
 interface InjectedExecOps {


### PR DESCRIPTION
graalvm 도커 이미지가 1기가가 넘는데 static linking 후 바이너리만 가져와서 용량을 줄였고
오라클 graalvm도 최신 lts에만 보안 업데이트를 해주는 조건이지만 무료로 풀려서 성능 면에서는 이게 좋을거 같아요
그리고 이미지 이걸로 쓰면 xargs 따로 설치할 필요 없는듯 빌드 되는걸 보니