### PR TITLE
spring dependency management 복구

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ import java.io.ByteArrayOutputStream
 
 plugins {
     id("org.springframework.boot") version "4.0.1" apply false
+    id("io.spring.dependency-management") version "1.1.7"
     id("org.jlleitschuh.gradle.ktlint") version "13.0.0"
     kotlin("jvm") version "2.2.0"
     kotlin("plugin.spring") version "2.2.0"
@@ -29,6 +30,12 @@ subprojects {
         plugin("org.jetbrains.kotlin.jvm")
         plugin("io.spring.dependency-management")
         plugin("kotlin-spring")
+    }
+
+    dependencyManagement {
+        imports {
+            mavenBom("org.springframework.boot:spring-boot-dependencies:4.0.1")
+        }
     }
 
     tasks.withType<KotlinCompile> {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -3,8 +3,6 @@ plugins {
 }
 
 dependencies {
-    api(platform(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES))
-
     api("org.jetbrains.kotlin:kotlin-reflect")
     api("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     api("tools.jackson.module:jackson-module-kotlin")


### PR DESCRIPTION
#380 에서 변경한 부분 롤백
최신버전에서 해당 에러 발생하지 않고 
`api(platform(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES))` 이 방식은 의존성이 더 여러개 붙어서 제거