### PR TITLE
테마 이름 중복 허용

### DIFF
--- a/core/src/main/kotlin/common/exception/ErrorType.kt
+++ b/core/src/main/kotlin/common/exception/ErrorType.kt
@@ -96,7 +96,8 @@ enum class ErrorType(
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, 40901, "이미 사용 중인 이메일입니다", "이미 사용 중인 이메일입니다", "회원가입 실패"),
     DUPLICATE_FRIEND(HttpStatus.CONFLICT, 40902, "이미 친구 관계이거나 친구 요청을 보냈습니다", "이미 친구 관계이거나 친구 요청을 보냈습니다"),
     INVALID_FRIEND(HttpStatus.CONFLICT, 40903, "친구 요청을 보낼 수 없는 유저입니다", "친구 요청을 보낼 수 없는 유저입니다"),
-    DUPLICATE_THEME_NAME(HttpStatus.CONFLICT, 40904, "중복된 테마 이름입니다", "동일한 테마 이름이 이미 있습니다. 다른 이름을 입력해 주세요", "테마 이름 중복"),
+
+    // DUPLICATE_THEME_NAME(HttpStatus.CONFLICT, 40904, "중복된 테마 이름입니다", "동일한 테마 이름이 이미 있습니다. 다른 이름을 입력해 주세요", "테마 이름 중복"),
     INVALID_THEME_TYPE(HttpStatus.CONFLICT, 40905, "적절하지 않은 유형의 테마입니다", "적절하지 않은 유형의 테마입니다"),
     DUPLICATE_POPUP_KEY(HttpStatus.CONFLICT, 40906, "중복된 팝업 키입니다", "중복된 팝업 키입니다"),
     ALREADY_DOWNLOADED_THEME(HttpStatus.CONFLICT, 40907, "이미 다운로드한 테마입니다", "이미 다운로드한 테마입니다"),

--- a/core/src/main/kotlin/common/exception/SnuttException.kt
+++ b/core/src/main/kotlin/common/exception/SnuttException.kt
@@ -174,8 +174,6 @@ object DuplicateFriendException : SnuttException(ErrorType.DUPLICATE_FRIEND)
 
 object InvalidFriendException : SnuttException(ErrorType.INVALID_FRIEND)
 
-object DuplicateThemeNameException : SnuttException(ErrorType.DUPLICATE_THEME_NAME)
-
 object InvalidThemeTypeException : SnuttException(ErrorType.INVALID_THEME_TYPE)
 
 object DuplicatePopupKeyException : SnuttException(ErrorType.DUPLICATE_POPUP_KEY)

--- a/core/src/main/kotlin/theme/data/TimetableTheme.kt
+++ b/core/src/main/kotlin/theme/data/TimetableTheme.kt
@@ -2,7 +2,6 @@ package com.wafflestudio.snutt.theme.data
 
 import org.springframework.data.annotation.Id
 import org.springframework.data.annotation.Transient
-import org.springframework.data.mongodb.core.index.CompoundIndex
 import org.springframework.data.mongodb.core.index.Indexed
 import org.springframework.data.mongodb.core.mapping.Document
 import org.springframework.data.mongodb.core.mapping.Field
@@ -10,7 +9,6 @@ import org.springframework.data.mongodb.core.mapping.FieldType
 import java.time.LocalDateTime
 
 @Document
-@CompoundIndex(def = "{ 'userId': 1, 'name': 1 }", unique = true)
 data class TimetableTheme(
     @Id
     var id: String? = null,

--- a/core/src/main/kotlin/theme/service/TimetableThemeService.kt
+++ b/core/src/main/kotlin/theme/service/TimetableThemeService.kt
@@ -2,7 +2,6 @@ package com.wafflestudio.snutt.theme.service
 
 import com.wafflestudio.snutt.common.enums.BasicThemeType
 import com.wafflestudio.snutt.common.exception.AlreadyDownloadedThemeException
-import com.wafflestudio.snutt.common.exception.DuplicateThemeNameException
 import com.wafflestudio.snutt.common.exception.InvalidThemeColorCountException
 import com.wafflestudio.snutt.common.exception.InvalidThemeTypeException
 import com.wafflestudio.snutt.common.exception.NotDefaultThemeErrorException
@@ -150,7 +149,6 @@ class TimetableThemeServiceImpl(
         colors: List<ColorSet>,
     ): TimetableTheme {
         if (colors.size !in 1..MAX_COLOR_COUNT) throw InvalidThemeColorCountException
-        if (timetableThemeRepository.existsByUserIdAndName(userId, name)) throw DuplicateThemeNameException
 
         val theme =
             TimetableTheme(
@@ -171,7 +169,6 @@ class TimetableThemeServiceImpl(
         val theme = getCustomTheme(userId, themeId)
 
         name?.let {
-            if (theme.name != it && timetableThemeRepository.existsByUserIdAndName(userId, it)) throw DuplicateThemeNameException
             theme.name = it
         }
 


### PR DESCRIPTION
테마마켓 도입 이전에 한 사람이 테마 이름 같은거 2개 가질수 없어서 인덱스를 걸어놨고 중복 체크도 했는데
테마마켓에서 다운받은 테마가 이름이 겹치는 경우 지금 에러가 나고 있고, 이름이 중복된다고 문제가 생기지 않을거 같다고 해서 허용할게요