### PR TITLE
빈자리알림 검색 페이지 요청 시 학기 명시

### DIFF
--- a/batch/src/main/kotlin/sugangsnu/common/SugangSnuRepository.kt
+++ b/batch/src/main/kotlin/sugangsnu/common/SugangSnuRepository.kt
@@ -51,13 +51,19 @@ class SugangSnuRepository(
             """.trimIndent().replace("\n", "")
     }
 
-    suspend fun getSearchPageHtml(pageNo: Int = 1): PooledDataBuffer =
+    suspend fun getSearchPageHtml(
+        year: Int,
+        semester: Semester,
+        pageNo: Int = 1,
+    ): PooledDataBuffer =
         sugangSnuApi
             .get()
             .uri { builder ->
                 builder
                     .path(SUGANG_SNU_SEARCH_PATH)
                     .query(DEFAULT_SEARCH_PAGE_PARAMS)
+                    .queryParam("srchOpenSchyy", year)
+                    .queryParam("srchOpenShtm", convertSemesterToSugangSnuSearchString(semester))
                     .queryParam("pageNo", pageNo)
                     .build()
             }.accept(MediaType.TEXT_HTML)

--- a/batch/src/main/kotlin/sugangsnu/job/vacancynotification/service/VacancyNotifierService.kt
+++ b/batch/src/main/kotlin/sugangsnu/job/vacancynotification/service/VacancyNotifierService.kt
@@ -65,7 +65,7 @@ class VacancyNotifierServiceImpl(
         log.info("시작: ${registrationPhase.name}")
         val pageCount =
             runCatching {
-                getPageCount()
+                getPageCount(coursebook)
             }.getOrElse {
                 log.error("에러가 발생했거나 부하 기간입니다. {}", it.message, it)
                 delay(30L.seconds)
@@ -77,7 +77,7 @@ class VacancyNotifierServiceImpl(
 
         // 수강 사이트 부하를 분산하기 위해 강의 전체를 20등분해서 각각 요청
         (1..pageCount).chunked(pageCount / 20).forEach { chunkedPages ->
-            val registrationStatus = getRegistrationStatus(chunkedPages)
+            val registrationStatus = getRegistrationStatus(chunkedPages, coursebook)
             if (registrationStatus.all { it.registrationCount == 0 }) return VacancyNotificationJobResult.REGISTRATION_IS_NOT_STARTED
 
             val registrationStatusMap =
@@ -157,19 +157,22 @@ class VacancyNotifierServiceImpl(
             this.quota == this.registrationCount
         }
 
-    private suspend fun getPageCount(): Int {
-        val firstPageContent = getSugangSnuSearchContent(1)
+    private suspend fun getPageCount(coursebook: Coursebook): Int {
+        val firstPageContent = getSugangSnuSearchContent(1, coursebook)
         val totalCount =
             firstPageContent.select("div.content > div.search-result-con > small > em").text().toInt()
         return (totalCount + 9) / COUNT_PER_PAGE
     }
 
-    private suspend fun getRegistrationStatus(pages: List<Int>): List<RegistrationStatus> =
+    private suspend fun getRegistrationStatus(
+        pages: List<Int>,
+        coursebook: Coursebook,
+    ): List<RegistrationStatus> =
         supervisorScope {
             pages
                 .map { page ->
                     async {
-                        getSugangSnuSearchContent(page).extractRegistrationStatus()
+                        getSugangSnuSearchContent(page, coursebook).extractRegistrationStatus()
                     }
                 }.awaitAll()
                 .flatten()
@@ -211,8 +214,16 @@ class VacancyNotifierServiceImpl(
                     }
             }
 
-    private suspend fun getSugangSnuSearchContent(pageNo: Int): Element {
-        val webPageDataBuffer = sugangSnuRepository.getSearchPageHtml(pageNo)
+    private suspend fun getSugangSnuSearchContent(
+        pageNo: Int,
+        coursebook: Coursebook,
+    ): Element {
+        val webPageDataBuffer =
+            sugangSnuRepository.getSearchPageHtml(
+                year = coursebook.year,
+                semester = coursebook.semester,
+                pageNo = pageNo,
+            )
         return try {
             Jsoup
                 .parse(webPageDataBuffer.asInputStream(), Charsets.UTF_8.name(), "")


### PR DESCRIPTION
>수강신청 사이트가 더 이상 “학년도/학기 없는 검색 요청”에 기본 총 건수를 채워주지 않아서, 총 건수 \<em\>이 빈 값으로 내려오고 있습니다. 수정 방향은 getSearchPageHtml()에 coursebook.year, coursebook.semester 기반의 srchOpenSchyy, srchOpenShtm을 넘기도록 바꾸는 쪽입니다.
