### PR TITLE
search_query 정렬 시 페이지 간 중복 id 수정

### DIFF
--- a/core/src/main/kotlin/common/enums/SortCriteria.kt
+++ b/core/src/main/kotlin/common/enums/SortCriteria.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.snutt.common.enums
 
 import com.fasterxml.jackson.annotation.JsonValue
+import com.wafflestudio.snutt.common.extension.asc
 import com.wafflestudio.snutt.common.extension.desc
 import com.wafflestudio.snutt.lectures.data.EvInfo
 import com.wafflestudio.snutt.lectures.data.Lecture
@@ -28,8 +29,8 @@ enum class SortCriteria(
 
         fun getSort(sortCriteria: SortCriteria?): Sort =
             when (sortCriteria) {
-                RATING_DESC -> (Lecture::evInfo / EvInfo::avgRating).desc()
-                COUNT_DESC -> (Lecture::evInfo / EvInfo::count).desc()
+                RATING_DESC -> (Lecture::evInfo / EvInfo::avgRating).desc().and(Lecture::id.asc())
+                COUNT_DESC -> (Lecture::evInfo / EvInfo::count).desc().and(Lecture::id.asc())
                 // RATING_ASC -> (Lecture::evInfo / EvInfo::avgRating).asc()
                 // COUNT_ASC -> (Lecture::evInfo / EvInfo::count).asc()
                 else -> Sort.unsorted()


### PR DESCRIPTION
## Summary
- `COUNT_DESC`(강의평 많은 순), `RATING_DESC`(평점 높은 순) 정렬 시 `evInfo.count` / `evInfo.avgRating` 단일 키만으로 정렬되어, 동일 값 lecture들이 페이지 경계에서 임의 순서로 섞여 인접 페이지 간 같은 id가 중복 노출되던 문제 수정
- `Lecture::id.asc()`를 secondary sort로 추가하여 결정적(deterministic) 정렬 보장 (`_id`는 unique + indexed라 비용 거의 없음)

## Test plan
- [ ] `./gradlew :core:compileKotlin` 통과 (확인 완료)
- [ ] 로컬 dev에서 `POST /v1/search_query` 를 sortCriteria=`강의평 많은 순`으로 page=0..N 순회 → 누적 id 집합에 중복 0 확인
- [ ] 동일하게 `평점 높은 순` 도 중복 0 확인
- [ ] `기본값` 정렬은 동작/순서 변화 없음 sanity check
- [ ] 같은 쿼리/페이지 두 번 호출 시 응답 순서 동일한지(결정성) 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)