### PR TITLE
강의일기장 알림 수동 트리거 dev endpoint 추가

### DIFF
--- a/api/src/main/kotlin/controller/AdminController.kt
+++ b/api/src/main/kotlin/controller/AdminController.kt
@@ -12,6 +12,7 @@ import com.wafflestudio.snutt.common.storage.dto.FileUploadUriDto
 import com.wafflestudio.snutt.diary.data.DiaryDailyClassType
 import com.wafflestudio.snutt.diary.data.DiaryQuestion
 import com.wafflestudio.snutt.diary.dto.request.DiaryAddQuestionRequestDto
+import com.wafflestudio.snutt.diary.service.DiaryNotifierService
 import com.wafflestudio.snutt.diary.service.DiaryService
 import com.wafflestudio.snutt.filter.SnuttAdminApiFilterTarget
 import com.wafflestudio.snutt.notification.service.NotificationAdminService
@@ -46,6 +47,7 @@ class AdminController(
     private val storageService: StorageService,
     private val popupService: PopupService,
     private val diaryService: DiaryService,
+    private val diaryNotifierService: DiaryNotifierService,
     private val semesterRegistrationPeriodService: SemesterRegistrationPeriodService,
 ) {
     @PostMapping("/insert_noti")
@@ -149,6 +151,12 @@ class AdminController(
         @PathVariable id: String,
     ): OkResponse {
         diaryService.removeQuestion(id)
+        return OkResponse()
+    }
+
+    @PostMapping("/diary/notifier/trigger")
+    suspend fun triggerDiaryNotifier(): OkResponse {
+        diaryNotifierService.triggerNotifierManually()
         return OkResponse()
     }
 

--- a/core/src/main/kotlin/common/exception/ErrorType.kt
+++ b/core/src/main/kotlin/common/exception/ErrorType.kt
@@ -113,4 +113,6 @@ enum class ErrorType(
         "현재 Coursebook이 수강신청 사이트보다 최근입니다.",
     ),
     REGISTRATION_PERIOD_NOT_SET(HttpStatus.INTERNAL_SERVER_ERROR, 50003, "학기에 대한 수강신청 기간이 설정되지 않았습니다", "학기에 대한 수강신청 기간이 설정되지 않았습니다"),
+
+    NOT_ALLOWED_IN_PROD(HttpStatus.FORBIDDEN, 40300, "프로덕션 환경에서는 사용할 수 없는 기능입니다", "프로덕션 환경에서는 사용할 수 없는 기능입니다"),
 }

--- a/core/src/main/kotlin/common/exception/SnuttException.kt
+++ b/core/src/main/kotlin/common/exception/SnuttException.kt
@@ -191,3 +191,5 @@ object DynamicLinkGenerationFailedException : SnuttException(ErrorType.DYNAMIC_L
 object CoursebookRecentThanSugangSnuException : SnuttException(ErrorType.COURSEBOOK_RECENT_THAN_SUGANGSNU)
 
 object RegistrationPeriodNotSetException : SnuttException(ErrorType.REGISTRATION_PERIOD_NOT_SET)
+
+object NotAllowedInProdException : SnuttException(ErrorType.NOT_ALLOWED_IN_PROD)

--- a/core/src/main/kotlin/diary/service/DiaryNotifierService.kt
+++ b/core/src/main/kotlin/diary/service/DiaryNotifierService.kt
@@ -2,6 +2,7 @@ package com.wafflestudio.snutt.diary.service
 
 import com.wafflestudio.snutt.common.cache.Cache
 import com.wafflestudio.snutt.common.cache.CacheKey
+import com.wafflestudio.snutt.common.exception.NotAllowedInProdException
 import com.wafflestudio.snutt.common.push.DeeplinkType
 import com.wafflestudio.snutt.common.push.dto.PushMessage
 import com.wafflestudio.snutt.config.PhaseUtils
@@ -18,6 +19,8 @@ import java.time.Instant
 
 interface DiaryNotifierService {
     suspend fun sendNotifier()
+
+    suspend fun triggerNotifierManually()
 }
 
 @Service
@@ -36,6 +39,17 @@ class DiaryNotifierServiceImpl(
     @Scheduled(cron = "0 0 19 * * MON,WED,FRI", zone = "Asia/Seoul")
     override suspend fun sendNotifier() {
         if (PhaseUtils.getPhase().isProd) return
+        sendDiaryNotifications()
+    }
+
+    override suspend fun triggerNotifierManually() {
+        if (PhaseUtils.getPhase().isProd) {
+            throw NotAllowedInProdException
+        }
+        sendDiaryNotifications()
+    }
+
+    private suspend fun sendDiaryNotifications() {
         val lockKey = CacheKey.LOCK_SEND_LECTURE_DIARY_NOTIFICATION.build()
         cache.withLock(lockKey) {
             try {

--- a/core/src/main/kotlin/diary/service/DiaryNotifierService.kt
+++ b/core/src/main/kotlin/diary/service/DiaryNotifierService.kt
@@ -32,9 +32,8 @@ class DiaryNotifierServiceImpl(
 ) : DiaryNotifierService {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
-    companion object {
-        val SAMPLE_RATE = if (PhaseUtils.getPhase().isProd) 0.1 else 1.0
-    }
+    private val sampleRate: Double
+        get() = if (PhaseUtils.getPhase().isProd) 0.1 else 1.0
 
     @Scheduled(cron = "0 0 19 * * MON,WED,FRI", zone = "Asia/Seoul")
     override suspend fun sendNotifier() {
@@ -63,7 +62,7 @@ class DiaryNotifierServiceImpl(
                 val totalCount = timetableRepository.countAllByIsPrimaryTrueAndYearAndSemester(currentYear, currentSemester)
                 val sampledUserIdPrimaryTimetableMap =
                     timetableRepository
-                        .samplePrimaryOfSizeByYearAndSemester((totalCount * SAMPLE_RATE).toLong(), currentYear, currentSemester)
+                        .samplePrimaryOfSizeByYearAndSemester((totalCount * sampleRate).toLong(), currentYear, currentSemester)
                         .toList()
                         .filter { it.lectures.size > 2 }
                         .associateBy { it.userId }


### PR DESCRIPTION
## Summary
- `DiaryNotifierService`에 `triggerNotifierManually()` 추가 (prod에서는 `NotAllowedInProdException` 발생)
- `POST /admin/diary/notifier/trigger` 어드민 endpoint 추가 — M/W/F 스케줄 잡과 동일한 로직을 수동으로 실행
- prod 환경 차단용 `NOT_ALLOWED_IN_PROD` (HTTP 403, code 40300) 에러코드 신설

## Test plan
- [ ] dev 환경에 배포 후 `POST /admin/diary/notifier/trigger` 호출 시 알림이 정상 전송되는지 확인
- [ ] prod 환경에서 호출 시 403 (NOT_ALLOWED_IN_PROD) 응답이 반환되는지 확인
- [ ] 기존 M/W/F 스케줄 잡 동작이 변하지 않았는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)