### PR TITLE
강의 목록에서 기본적으로 id 오름차순 정렬

### DIFF
--- a/core/src/main/kotlin/common/enums/SortCriteria.kt
+++ b/core/src/main/kotlin/common/enums/SortCriteria.kt
@@ -34,6 +34,6 @@ enum class SortCriteria(
                 // RATING_ASC -> (Lecture::evInfo / EvInfo::avgRating).asc()
                 // COUNT_ASC -> (Lecture::evInfo / EvInfo::count).asc()
                 else -> Sort.unsorted()
-            }
+            }.and(Lecture::id.asc())
     }
 }


### PR DESCRIPTION
https://wafflestudio.slack.com/archives/C8M9NUBBR/p1778167672176969?thread_ts=1777742297.907809&cid=C8M9NUBBR
안정적인 순서 보장을 위해서입니다