### PR TITLE
어드민 이메일로 유저 검색 API 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -280,4 +280,8 @@ gradle-app.setting
 # docs html,css
 api/src/main/resources/static/docs
 
+# AI tooling state
+.claude/
+.omc/
+
 # End of https://www.toptal.com/developers/gitignore/api/java,kotlin,intellij,vim,macos,windows,linux,gradle

--- a/api/src/main/kotlin/controller/AdminController.kt
+++ b/api/src/main/kotlin/controller/AdminController.kt
@@ -22,6 +22,8 @@ import com.wafflestudio.snutt.popup.service.PopupService
 import com.wafflestudio.snutt.registrationperiod.data.RegistrationDate
 import com.wafflestudio.snutt.registrationperiod.data.SemesterRegistrationPeriod
 import com.wafflestudio.snutt.registrationperiod.service.SemesterRegistrationPeriodService
+import com.wafflestudio.snutt.users.dto.AdminUserSearchResponse
+import com.wafflestudio.snutt.users.service.UserService
 import notification.dto.InsertNotificationRequest
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -49,6 +51,7 @@ class AdminController(
     private val diaryService: DiaryService,
     private val diaryNotifierService: DiaryNotifierService,
     private val semesterRegistrationPeriodService: SemesterRegistrationPeriodService,
+    private val userService: UserService,
 ) {
     @PostMapping("/insert_noti")
     suspend fun insertNotification(
@@ -187,4 +190,9 @@ class AdminController(
         semesterRegistrationPeriodService.delete(year, semester)
         return OkResponse()
     }
+
+    @GetMapping("/users/search")
+    suspend fun searchUsersByEmail(
+        @RequestParam email: String,
+    ): List<AdminUserSearchResponse> = userService.getUsersByEmail(email).map { AdminUserSearchResponse.from(it) }
 }

--- a/core/src/main/kotlin/users/data/User.kt
+++ b/core/src/main/kotlin/users/data/User.kt
@@ -10,6 +10,7 @@ import java.time.LocalDateTime
 data class User(
     @Id
     val id: String? = null,
+    @Indexed(sparse = true)
     var email: String?,
     @Indexed(unique = true, sparse = true)
     var nickname: String,

--- a/core/src/main/kotlin/users/data/User.kt
+++ b/core/src/main/kotlin/users/data/User.kt
@@ -10,7 +10,6 @@ import java.time.LocalDateTime
 data class User(
     @Id
     val id: String? = null,
-    @Indexed(sparse = true)
     var email: String?,
     @Indexed(unique = true, sparse = true)
     var nickname: String,

--- a/core/src/main/kotlin/users/dto/AdminUserSearchResponse.kt
+++ b/core/src/main/kotlin/users/dto/AdminUserSearchResponse.kt
@@ -1,0 +1,56 @@
+package com.wafflestudio.snutt.users.dto
+
+import com.wafflestudio.snutt.auth.AuthProvider
+import com.wafflestudio.snutt.users.data.User
+import java.time.LocalDateTime
+
+data class AdminUserSearchResponse(
+    val id: String,
+    val email: String?,
+    val isEmailVerified: Boolean?,
+    val nickname: String,
+    val localId: String?,
+    val isAdmin: Boolean,
+    val active: Boolean,
+    val regDate: LocalDateTime,
+    val lastLoginTimestamp: Long,
+    val authProviders: List<AuthProvider>,
+    val socialAccounts: SocialAccounts,
+) {
+    data class SocialAccounts(
+        val googleEmail: String?,
+        val kakaoEmail: String?,
+        val appleEmail: String?,
+        val facebookName: String?,
+    )
+
+    companion object {
+        fun from(user: User): AdminUserSearchResponse =
+            AdminUserSearchResponse(
+                id = user.id!!,
+                email = user.email,
+                isEmailVerified = user.isEmailVerified,
+                nickname = user.nickname,
+                localId = user.credential.localId,
+                isAdmin = user.isAdmin,
+                active = user.active,
+                regDate = user.regDate,
+                lastLoginTimestamp = user.lastLoginTimestamp,
+                authProviders =
+                    listOfNotNull(
+                        user.credential.localId?.let { AuthProvider.LOCAL },
+                        user.credential.fbId?.let { AuthProvider.FACEBOOK },
+                        user.credential.googleSub?.let { AuthProvider.GOOGLE },
+                        user.credential.kakaoSub?.let { AuthProvider.KAKAO },
+                        user.credential.appleSub?.let { AuthProvider.APPLE },
+                    ),
+                socialAccounts =
+                    SocialAccounts(
+                        googleEmail = user.credential.googleEmail,
+                        kakaoEmail = user.credential.kakaoEmail,
+                        appleEmail = user.credential.appleEmail,
+                        facebookName = user.credential.fbName,
+                    ),
+            )
+    }
+}

--- a/core/src/main/kotlin/users/repository/UserRepository.kt
+++ b/core/src/main/kotlin/users/repository/UserRepository.kt
@@ -34,7 +34,7 @@ interface UserRepository : CoroutineCrudRepository<User, String> {
 
     suspend fun findByEmailIgnoreCaseAndIsEmailVerifiedTrueAndActiveTrue(email: String): User?
 
-    suspend fun findAllByEmailIgnoreCaseAndActiveTrue(email: String): List<User>
+    suspend fun findAllByEmailIgnoreCase(email: String): List<User>
 
     suspend fun existsByCredentialFbIdAndActiveTrue(fbId: String): Boolean
 

--- a/core/src/main/kotlin/users/repository/UserRepository.kt
+++ b/core/src/main/kotlin/users/repository/UserRepository.kt
@@ -34,6 +34,8 @@ interface UserRepository : CoroutineCrudRepository<User, String> {
 
     suspend fun findByEmailIgnoreCaseAndIsEmailVerifiedTrueAndActiveTrue(email: String): User?
 
+    suspend fun findAllByEmailIgnoreCaseAndActiveTrue(email: String): List<User>
+
     suspend fun existsByCredentialFbIdAndActiveTrue(fbId: String): Boolean
 
     suspend fun existsByCredentialGoogleSubAndActiveTrue(googleSub: String): Boolean

--- a/core/src/main/kotlin/users/repository/UserRepository.kt
+++ b/core/src/main/kotlin/users/repository/UserRepository.kt
@@ -34,7 +34,7 @@ interface UserRepository : CoroutineCrudRepository<User, String> {
 
     suspend fun findByEmailIgnoreCaseAndIsEmailVerifiedTrueAndActiveTrue(email: String): User?
 
-    suspend fun findAllByEmailIgnoreCase(email: String): List<User>
+    suspend fun findAllByEmail(email: String): List<User>
 
     suspend fun existsByCredentialFbIdAndActiveTrue(fbId: String): Boolean
 

--- a/core/src/main/kotlin/users/service/UserService.kt
+++ b/core/src/main/kotlin/users/service/UserService.kt
@@ -605,7 +605,7 @@ class UserServiceImpl(
         redisTemplate.delete(RESET_PASSWORD_CODE_PREFIX + user.id).subscribe()
     }
 
-    override suspend fun getUsersByEmail(email: String): List<User> = userRepository.findAllByEmailIgnoreCaseAndActiveTrue(email)
+    override suspend fun getUsersByEmail(email: String): List<User> = userRepository.findAllByEmailIgnoreCase(email)
 
     private suspend fun saveNewVerificationValue(
         email: String,

--- a/core/src/main/kotlin/users/service/UserService.kt
+++ b/core/src/main/kotlin/users/service/UserService.kt
@@ -605,7 +605,7 @@ class UserServiceImpl(
         redisTemplate.delete(RESET_PASSWORD_CODE_PREFIX + user.id).subscribe()
     }
 
-    override suspend fun getUsersByEmail(email: String): List<User> = userRepository.findAllByEmailIgnoreCase(email)
+    override suspend fun getUsersByEmail(email: String): List<User> = userRepository.findAllByEmail(email)
 
     private suspend fun saveNewVerificationValue(
         email: String,

--- a/core/src/main/kotlin/users/service/UserService.kt
+++ b/core/src/main/kotlin/users/service/UserService.kt
@@ -131,6 +131,8 @@ interface UserService {
         newPassword: String,
         code: String,
     )
+
+    suspend fun getUsersByEmail(email: String): List<User>
 }
 
 @Service
@@ -602,6 +604,8 @@ class UserServiceImpl(
         userRepository.save(user)
         redisTemplate.delete(RESET_PASSWORD_CODE_PREFIX + user.id).subscribe()
     }
+
+    override suspend fun getUsersByEmail(email: String): List<User> = userRepository.findAllByEmailIgnoreCaseAndActiveTrue(email)
 
     private suspend fun saveNewVerificationValue(
         email: String,


### PR DESCRIPTION
## What
어드민 권한으로 이메일을 입력해 유저를 조회하는 API를 추가했어요.
- `GET /v1/admin/users/search?email={email}` (다건 응답)
- 응답에 기본 정보 + attached된 로그인 수단(`authProviders`) 포함
- 비활성 유저도 검색됨
- 단순화를 위해 case-sensitive 매칭 (인덱스 활용도 우선)

## Why
- 본인 로그인 방법(소셜/로컬)을 까먹은 유저 문의가 종종 들어오는데, 현재는 DB를 직접 뒤져야 답을 줄 수 있었어요.
- 어드민에서 바로 확인 가능하면 문의 대응 속도가 빨라져요.

## Test plan
- [ ] dev에서 어드민 계정으로 `/v1/admin/users/search?email=...` 호출하여 본인 계정 조회되는지 확인
- [ ] 비어드민 토큰으로 호출 시 403 응답
- [ ] 존재하지 않는 이메일 입력 시 빈 배열 반환
- [ ] 비활성 유저도 결과에 포함되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)