### PR TITLE
이메일 인덱스 추가 및 collation 사용

### DIFF
--- a/core/src/main/kotlin/users/data/User.kt
+++ b/core/src/main/kotlin/users/data/User.kt
@@ -6,13 +6,16 @@ import org.springframework.data.mongodb.core.index.Indexed
 import org.springframework.data.mongodb.core.mapping.Document
 import java.time.LocalDateTime
 
+const val EMAIL_CASE_INSENSITIVE_COLLATION = "{ 'locale': 'en', 'strength': 2 }"
+
 @Document("users")
 data class User(
     @Id
     val id: String? = null,
     @Indexed(
         unique = true,
-        partialFilter = "{ 'active': true, 'isEmailVerified': true, 'email': { '\$type': 'string' } }",
+        partialFilter = $$"{ 'active': true, 'isEmailVerified': true, 'email': { '$type': 'string' } }",
+        collation = EMAIL_CASE_INSENSITIVE_COLLATION,
     )
     var email: String?,
     @Indexed(unique = true, sparse = true)

--- a/core/src/main/kotlin/users/data/User.kt
+++ b/core/src/main/kotlin/users/data/User.kt
@@ -10,6 +10,10 @@ import java.time.LocalDateTime
 data class User(
     @Id
     val id: String? = null,
+    @Indexed(
+        unique = true,
+        partialFilter = "{ 'active': true, 'isEmailVerified': true, 'email': { '\$type': 'string' } }",
+    )
     var email: String?,
     @Indexed(unique = true, sparse = true)
     var nickname: String,

--- a/core/src/main/kotlin/users/repository/UserRepository.kt
+++ b/core/src/main/kotlin/users/repository/UserRepository.kt
@@ -1,7 +1,9 @@
 package com.wafflestudio.snutt.users.repository
 
+import com.wafflestudio.snutt.users.data.EMAIL_CASE_INSENSITIVE_COLLATION
 import com.wafflestudio.snutt.users.data.User
 import kotlinx.coroutines.flow.Flow
+import org.springframework.data.mongodb.repository.Query
 import org.springframework.data.repository.kotlin.CoroutineCrudRepository
 
 interface UserRepository : CoroutineCrudRepository<User, String> {
@@ -30,8 +32,17 @@ interface UserRepository : CoroutineCrudRepository<User, String> {
 
     suspend fun findAllByIdInAndActiveTrue(ids: List<String>): List<User>
 
+    @Query(
+        value = "{ 'email': ?0, 'isEmailVerified': true, 'active': true }",
+        exists = true,
+        collation = EMAIL_CASE_INSENSITIVE_COLLATION,
+    )
     suspend fun existsByEmailAndIsEmailVerifiedTrueAndActiveTrue(email: String): Boolean
 
+    @Query(
+        value = "{ 'email': ?0, 'isEmailVerified': true, 'active': true }",
+        collation = EMAIL_CASE_INSENSITIVE_COLLATION,
+    )
     suspend fun findByEmailAndIsEmailVerifiedTrueAndActiveTrue(email: String): User?
 
     suspend fun findAllByEmail(email: String): List<User>

--- a/core/src/main/kotlin/users/repository/UserRepository.kt
+++ b/core/src/main/kotlin/users/repository/UserRepository.kt
@@ -45,6 +45,10 @@ interface UserRepository : CoroutineCrudRepository<User, String> {
     )
     suspend fun findByEmailAndIsEmailVerifiedTrueAndActiveTrue(email: String): User?
 
+    @Query(
+        value = "{ 'email': ?0 }",
+        collation = EMAIL_CASE_INSENSITIVE_COLLATION,
+    )
     suspend fun findAllByEmail(email: String): List<User>
 
     suspend fun existsByCredentialFbIdAndActiveTrue(fbId: String): Boolean

--- a/core/src/main/kotlin/users/repository/UserRepository.kt
+++ b/core/src/main/kotlin/users/repository/UserRepository.kt
@@ -30,9 +30,9 @@ interface UserRepository : CoroutineCrudRepository<User, String> {
 
     suspend fun findAllByIdInAndActiveTrue(ids: List<String>): List<User>
 
-    suspend fun existsByEmailIgnoreCaseAndIsEmailVerifiedTrueAndActiveTrue(email: String): Boolean
+    suspend fun existsByEmailAndIsEmailVerifiedTrueAndActiveTrue(email: String): Boolean
 
-    suspend fun findByEmailIgnoreCaseAndIsEmailVerifiedTrueAndActiveTrue(email: String): User?
+    suspend fun findByEmailAndIsEmailVerifiedTrueAndActiveTrue(email: String): User?
 
     suspend fun findAllByEmail(email: String): List<User>
 

--- a/core/src/main/kotlin/users/service/AuthService.kt
+++ b/core/src/main/kotlin/users/service/AuthService.kt
@@ -70,8 +70,8 @@ class AuthServiceImpl(
     override fun isValidEmail(email: String) = email.trim().matches(emailRegex)
 
     override fun isValidSnuMail(email: String): Boolean {
-        val trimmedEmail = email.trim()
-        return trimmedEmail.matches(emailRegex) && trimmedEmail.endsWith("@snu.ac.kr", ignoreCase = true)
+        val email = email.trim()
+        return email.matches(emailRegex) && email.endsWith("@snu.ac.kr", ignoreCase = true)
     }
 
     override fun isMatchedPassword(

--- a/core/src/main/kotlin/users/service/AuthService.kt
+++ b/core/src/main/kotlin/users/service/AuthService.kt
@@ -10,7 +10,6 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import tools.jackson.databind.ObjectMapper
-import java.util.Locale
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 
@@ -22,8 +21,6 @@ interface AuthService {
     fun isValidEmail(email: String): Boolean
 
     fun isValidSnuMail(email: String): Boolean
-
-    fun normalizeEmail(email: String): String
 
     fun isMatchedPassword(
         user: User,
@@ -70,14 +67,12 @@ class AuthServiceImpl(
 
     override fun isValidPassword(password: String) = password.matches(passwordRegex)
 
-    override fun isValidEmail(email: String) = normalizeEmail(email).matches(emailRegex)
+    override fun isValidEmail(email: String) = email.trim().matches(emailRegex)
 
     override fun isValidSnuMail(email: String): Boolean {
-        val normalizedEmail = normalizeEmail(email)
-        return normalizedEmail.matches(emailRegex) && normalizedEmail.endsWith("@snu.ac.kr")
+        val trimmedEmail = email.trim()
+        return trimmedEmail.matches(emailRegex) && trimmedEmail.endsWith("@snu.ac.kr", ignoreCase = true)
     }
-
-    override fun normalizeEmail(email: String) = email.trim().lowercase(Locale.ROOT)
 
     override fun isMatchedPassword(
         user: User,

--- a/core/src/main/kotlin/users/service/AuthService.kt
+++ b/core/src/main/kotlin/users/service/AuthService.kt
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import tools.jackson.databind.ObjectMapper
+import java.util.Locale
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 
@@ -21,6 +22,8 @@ interface AuthService {
     fun isValidEmail(email: String): Boolean
 
     fun isValidSnuMail(email: String): Boolean
+
+    fun normalizeEmail(email: String): String
 
     fun isMatchedPassword(
         user: User,
@@ -67,9 +70,14 @@ class AuthServiceImpl(
 
     override fun isValidPassword(password: String) = password.matches(passwordRegex)
 
-    override fun isValidEmail(email: String) = email.matches(emailRegex)
+    override fun isValidEmail(email: String) = normalizeEmail(email).matches(emailRegex)
 
-    override fun isValidSnuMail(email: String) = email.matches(emailRegex) && email.endsWith("@snu.ac.kr")
+    override fun isValidSnuMail(email: String): Boolean {
+        val normalizedEmail = normalizeEmail(email)
+        return normalizedEmail.matches(emailRegex) && normalizedEmail.endsWith("@snu.ac.kr")
+    }
+
+    override fun normalizeEmail(email: String) = email.trim().lowercase(Locale.ROOT)
 
     override fun isMatchedPassword(
         user: User,

--- a/core/src/main/kotlin/users/service/UserService.kt
+++ b/core/src/main/kotlin/users/service/UserService.kt
@@ -236,7 +236,7 @@ class UserServiceImpl(
         val credential = authService.buildFacebookCredential(oauth2UserResponse)
 
         if (oauth2UserResponse.email != null) {
-            findByUserEmail(oauth2UserResponse.email)?.let {
+            userRepository.findByEmailAndIsEmailVerifiedTrueAndActiveTrue(oauth2UserResponse.email)?.let {
                 throw DuplicateEmailException(getAttachedAuthProviders(it))
             }
         } else {
@@ -260,7 +260,7 @@ class UserServiceImpl(
         }
 
         checkNotNull(oauth2UserResponse.email) { "google email is null: $oauth2UserResponse" }
-        findByUserEmail(oauth2UserResponse.email)?.let {
+        userRepository.findByEmailAndIsEmailVerifiedTrueAndActiveTrue(oauth2UserResponse.email)?.let {
             throw DuplicateEmailException(getAttachedAuthProviders(it))
         }
 
@@ -283,7 +283,7 @@ class UserServiceImpl(
         }
 
         checkNotNull(oauth2UserResponse.email) { "kakao email is null: $oauth2UserResponse" }
-        findByUserEmail(oauth2UserResponse.email)?.let {
+        userRepository.findByEmailAndIsEmailVerifiedTrueAndActiveTrue(oauth2UserResponse.email)?.let {
             throw DuplicateEmailException(getAttachedAuthProviders(it))
         }
 
@@ -310,7 +310,7 @@ class UserServiceImpl(
         }
 
         checkNotNull(oauth2UserResponse.email) { "apple email is null: $oauth2UserResponse" }
-        findByUserEmail(oauth2UserResponse.email)?.let {
+        userRepository.findByEmailAndIsEmailVerifiedTrueAndActiveTrue(oauth2UserResponse.email)?.let {
             throw DuplicateEmailException(getAttachedAuthProviders(it))
         }
 
@@ -350,14 +350,14 @@ class UserServiceImpl(
         isEmailVerified: Boolean,
     ): LoginResponse {
         val credentialHash = authService.generateCredentialHash(credential)
-        val trimmedEmail = email?.trim()
+        val email = email?.trim()
 
         val randomNickname = userNicknameService.generateUniqueRandomNickname()
 
         val user =
             User(
-                email = trimmedEmail,
-                isEmailVerified = if (trimmedEmail != null) isEmailVerified else false,
+                email = email,
+                isEmailVerified = if (email != null) isEmailVerified else false,
                 credential = credential,
                 credentialHash = credentialHash,
                 nickname = randomNickname,
@@ -386,16 +386,16 @@ class UserServiceImpl(
         user: User,
         email: String,
     ) {
-        val trimmedEmail = email.trim()
+        val email = email.trim()
         if (user.isEmailVerified == true) throw EmailAlreadyVerifiedException
-        if (!authService.isValidSnuMail(trimmedEmail)) throw InvalidEmailException
-        if (userRepository.existsByEmailAndIsEmailVerifiedTrueAndActiveTrue(trimmedEmail)) {
+        if (!authService.isValidSnuMail(email)) throw InvalidEmailException
+        if (userRepository.existsByEmailAndIsEmailVerifiedTrueAndActiveTrue(email)) {
             throw DuplicateEmailException(getAttachedAuthProviders(user))
         }
         val key = VERIFICATION_CODE_PREFIX + user.id
         val code = (Math.random() * 1000000).toInt().toString().padStart(6, '0')
-        saveNewVerificationValue(trimmedEmail, code, key)
-        mailService.sendUserMail(type = UserMailType.VERIFICATION, to = trimmedEmail, code = code)
+        saveNewVerificationValue(email, code, key)
+        mailService.sendUserMail(type = UserMailType.VERIFICATION, to = email, code = code)
     }
 
     override suspend fun verifyEmail(
@@ -404,15 +404,14 @@ class UserServiceImpl(
     ) {
         val key = VERIFICATION_CODE_PREFIX + user.id
         val value = checkVerificationValue(key, code)
-        val trimmedEmail = value.email.trim()
         user.apply {
-            email = trimmedEmail
+            email = value.email
             isEmailVerified = true
         }
         try {
             userRepository.save(user)
         } catch (e: DuplicateKeyException) {
-            val presentUser = userRepository.findByEmailAndIsEmailVerifiedTrueAndActiveTrue(trimmedEmail)
+            val presentUser = userRepository.findByEmailAndIsEmailVerifiedTrueAndActiveTrue(value.email)
             throw DuplicateEmailException(getAttachedAuthProviders(presentUser ?: user))
         }
         redisTemplate.delete(key).subscribe()
@@ -451,7 +450,7 @@ class UserServiceImpl(
         val token = socialLoginRequest.token
         val oauth2UserResponse = authService.socialLoginWithAccessToken(authProvider, token)
         if (oauth2UserResponse.email != null) {
-            val presentUser = findByUserEmail(oauth2UserResponse.email)
+            val presentUser = userRepository.findByEmailAndIsEmailVerifiedTrueAndActiveTrue(oauth2UserResponse.email)
             if (presentUser != null && presentUser.id != user.id) {
                 throw DuplicateEmailException(getAttachedAuthProviders(presentUser))
             }
@@ -578,13 +577,13 @@ class UserServiceImpl(
     }
 
     override suspend fun sendLocalIdToEmail(email: String) {
-        val trimmedEmail = email.trim()
-        val users = userRepository.findAllByEmail(trimmedEmail).filter { it.active }
+        val email = email.trim()
+        val users = userRepository.findAllByEmail(email).filter { it.active }
         if (users.isEmpty()) throw UserNotFoundException
 
         val accountInfo = buildFindIdAccountInfo(users)
         if (accountInfo.isBlank()) throw UserNotFoundException
-        mailService.sendUserMail(type = UserMailType.FIND_ID, to = trimmedEmail, accountInfo = accountInfo)
+        mailService.sendUserMail(type = UserMailType.FIND_ID, to = email, accountInfo = accountInfo)
     }
 
     private fun buildFindIdAccountInfo(users: List<User>): String {
@@ -615,13 +614,13 @@ class UserServiceImpl(
     }
 
     override suspend fun sendResetPasswordCode(email: String) {
-        val trimmedEmail = email.trim()
-        if (trimmedEmail.replace(emailMaskRegex, "*") == trimmedEmail) throw UpdateAppVersionException
-        val user = userRepository.findByEmailAndIsEmailVerifiedTrueAndActiveTrue(trimmedEmail) ?: throw UserNotFoundException
+        val email = email.trim()
+        if (email.replace(emailMaskRegex, "*") == email) throw UpdateAppVersionException
+        val user = userRepository.findByEmailAndIsEmailVerifiedTrueAndActiveTrue(email) ?: throw UserNotFoundException
         val key = RESET_PASSWORD_CODE_PREFIX + user.id
         val code = Base64.getUrlEncoder().encodeToString(Random.nextBytes(6))
-        saveNewVerificationValue(trimmedEmail, code, key)
-        mailService.sendUserMail(type = UserMailType.PASSWORD_RESET, to = trimmedEmail, code = code)
+        saveNewVerificationValue(email, code, key)
+        mailService.sendUserMail(type = UserMailType.PASSWORD_RESET, to = email, code = code)
     }
 
     override suspend fun verifyResetPasswordCode(
@@ -656,7 +655,7 @@ class UserServiceImpl(
         redisTemplate.delete(RESET_PASSWORD_CODE_PREFIX + user.id).subscribe()
     }
 
-    override suspend fun getUsersByEmail(email: String): List<User> = userRepository.findAllByEmail(email)
+    override suspend fun getUsersByEmail(email: String): List<User> = userRepository.findAllByEmail(email.trim())
 
     private suspend fun saveNewVerificationValue(
         email: String,
@@ -686,8 +685,6 @@ class UserServiceImpl(
         redisTemplate.opsForValue().getAndAwait(key)?.let {
             mapper.readValue<RedisVerificationValue>(it)
         }
-
-    private suspend fun findByUserEmail(email: String): User? = userRepository.findByEmailAndIsEmailVerifiedTrueAndActiveTrue(email.trim())
 
     companion object {
         private val emailMaskRegex = Regex("(?<=.{3}).(?=.*@)")

--- a/core/src/main/kotlin/users/service/UserService.kt
+++ b/core/src/main/kotlin/users/service/UserService.kt
@@ -182,7 +182,7 @@ class UserServiceImpl(
     override suspend fun registerLocal(localRegisterRequest: LocalRegisterRequest): LoginResponse {
         val localId = localRegisterRequest.id
         val password = localRegisterRequest.password
-        val email = localRegisterRequest.email?.let(authService::normalizeEmail)
+        val email = localRegisterRequest.email?.trim()
 
         val cacheKey = CacheKey.LOCK_REGISTER_LOCAL.build(localId)
 
@@ -350,14 +350,14 @@ class UserServiceImpl(
         isEmailVerified: Boolean,
     ): LoginResponse {
         val credentialHash = authService.generateCredentialHash(credential)
-        val normalizedEmail = email?.let(authService::normalizeEmail)
+        val trimmedEmail = email?.trim()
 
         val randomNickname = userNicknameService.generateUniqueRandomNickname()
 
         val user =
             User(
-                email = normalizedEmail,
-                isEmailVerified = if (normalizedEmail != null) isEmailVerified else false,
+                email = trimmedEmail,
+                isEmailVerified = if (trimmedEmail != null) isEmailVerified else false,
                 credential = credential,
                 credentialHash = credentialHash,
                 nickname = randomNickname,
@@ -386,16 +386,16 @@ class UserServiceImpl(
         user: User,
         email: String,
     ) {
-        val normalizedEmail = authService.normalizeEmail(email)
+        val trimmedEmail = email.trim()
         if (user.isEmailVerified == true) throw EmailAlreadyVerifiedException
-        if (!authService.isValidSnuMail(normalizedEmail)) throw InvalidEmailException
-        if (userRepository.existsByEmailAndIsEmailVerifiedTrueAndActiveTrue(normalizedEmail)) {
+        if (!authService.isValidSnuMail(trimmedEmail)) throw InvalidEmailException
+        if (userRepository.existsByEmailAndIsEmailVerifiedTrueAndActiveTrue(trimmedEmail)) {
             throw DuplicateEmailException(getAttachedAuthProviders(user))
         }
         val key = VERIFICATION_CODE_PREFIX + user.id
         val code = (Math.random() * 1000000).toInt().toString().padStart(6, '0')
-        saveNewVerificationValue(normalizedEmail, code, key)
-        mailService.sendUserMail(type = UserMailType.VERIFICATION, to = normalizedEmail, code = code)
+        saveNewVerificationValue(trimmedEmail, code, key)
+        mailService.sendUserMail(type = UserMailType.VERIFICATION, to = trimmedEmail, code = code)
     }
 
     override suspend fun verifyEmail(
@@ -404,15 +404,15 @@ class UserServiceImpl(
     ) {
         val key = VERIFICATION_CODE_PREFIX + user.id
         val value = checkVerificationValue(key, code)
-        val normalizedEmail = authService.normalizeEmail(value.email)
+        val trimmedEmail = value.email.trim()
         user.apply {
-            email = normalizedEmail
+            email = trimmedEmail
             isEmailVerified = true
         }
         try {
             userRepository.save(user)
         } catch (e: DuplicateKeyException) {
-            val presentUser = userRepository.findByEmailAndIsEmailVerifiedTrueAndActiveTrue(normalizedEmail)
+            val presentUser = userRepository.findByEmailAndIsEmailVerifiedTrueAndActiveTrue(trimmedEmail)
             throw DuplicateEmailException(getAttachedAuthProviders(presentUser ?: user))
         }
         redisTemplate.delete(key).subscribe()
@@ -578,13 +578,13 @@ class UserServiceImpl(
     }
 
     override suspend fun sendLocalIdToEmail(email: String) {
-        val normalizedEmail = authService.normalizeEmail(email)
-        val users = userRepository.findAllByEmail(normalizedEmail).filter { it.active }
+        val trimmedEmail = email.trim()
+        val users = userRepository.findAllByEmail(trimmedEmail).filter { it.active }
         if (users.isEmpty()) throw UserNotFoundException
 
         val accountInfo = buildFindIdAccountInfo(users)
         if (accountInfo.isBlank()) throw UserNotFoundException
-        mailService.sendUserMail(type = UserMailType.FIND_ID, to = normalizedEmail, accountInfo = accountInfo)
+        mailService.sendUserMail(type = UserMailType.FIND_ID, to = trimmedEmail, accountInfo = accountInfo)
     }
 
     private fun buildFindIdAccountInfo(users: List<User>): String {
@@ -615,13 +615,13 @@ class UserServiceImpl(
     }
 
     override suspend fun sendResetPasswordCode(email: String) {
-        val normalizedEmail = authService.normalizeEmail(email)
-        if (normalizedEmail.replace(emailMaskRegex, "*") == normalizedEmail) throw UpdateAppVersionException
-        val user = userRepository.findByEmailAndIsEmailVerifiedTrueAndActiveTrue(normalizedEmail) ?: throw UserNotFoundException
+        val trimmedEmail = email.trim()
+        if (trimmedEmail.replace(emailMaskRegex, "*") == trimmedEmail) throw UpdateAppVersionException
+        val user = userRepository.findByEmailAndIsEmailVerifiedTrueAndActiveTrue(trimmedEmail) ?: throw UserNotFoundException
         val key = RESET_PASSWORD_CODE_PREFIX + user.id
         val code = Base64.getUrlEncoder().encodeToString(Random.nextBytes(6))
-        saveNewVerificationValue(normalizedEmail, code, key)
-        mailService.sendUserMail(type = UserMailType.PASSWORD_RESET, to = normalizedEmail, code = code)
+        saveNewVerificationValue(trimmedEmail, code, key)
+        mailService.sendUserMail(type = UserMailType.PASSWORD_RESET, to = trimmedEmail, code = code)
     }
 
     override suspend fun verifyResetPasswordCode(
@@ -687,8 +687,7 @@ class UserServiceImpl(
             mapper.readValue<RedisVerificationValue>(it)
         }
 
-    private suspend fun findByUserEmail(email: String): User? =
-        userRepository.findByEmailAndIsEmailVerifiedTrueAndActiveTrue(authService.normalizeEmail(email))
+    private suspend fun findByUserEmail(email: String): User? = userRepository.findByEmailAndIsEmailVerifiedTrueAndActiveTrue(email.trim())
 
     companion object {
         private val emailMaskRegex = Regex("(?<=.{3}).(?=.*@)")

--- a/core/src/main/kotlin/users/service/UserService.kt
+++ b/core/src/main/kotlin/users/service/UserService.kt
@@ -40,6 +40,7 @@ import com.wafflestudio.snutt.users.repository.UserRepository
 import org.slf4j.LoggerFactory
 import org.springframework.aot.hint.annotation.RegisterReflectionForBinding
 import org.springframework.context.ApplicationEventPublisher
+import org.springframework.dao.DuplicateKeyException
 import org.springframework.data.redis.core.ReactiveStringRedisTemplate
 import org.springframework.data.redis.core.getAndAwait
 import org.springframework.stereotype.Service
@@ -181,7 +182,7 @@ class UserServiceImpl(
     override suspend fun registerLocal(localRegisterRequest: LocalRegisterRequest): LoginResponse {
         val localId = localRegisterRequest.id
         val password = localRegisterRequest.password
-        val email = localRegisterRequest.email
+        val email = localRegisterRequest.email?.let(authService::normalizeEmail)
 
         val cacheKey = CacheKey.LOCK_REGISTER_LOCAL.build(localId)
 
@@ -191,7 +192,7 @@ class UserServiceImpl(
             if (!authService.isValidPassword(password)) throw InvalidPasswordException
             email?.let {
                 if (!authService.isValidEmail(email)) throw InvalidEmailException
-                userRepository.findByEmailIgnoreCaseAndIsEmailVerifiedTrueAndActiveTrue(email)?.let {
+                userRepository.findByEmailAndIsEmailVerifiedTrueAndActiveTrue(email)?.let {
                     throw DuplicateEmailException(getAttachedAuthProviders(it))
                 }
             }
@@ -235,7 +236,7 @@ class UserServiceImpl(
         val credential = authService.buildFacebookCredential(oauth2UserResponse)
 
         if (oauth2UserResponse.email != null) {
-            userRepository.findByEmailIgnoreCaseAndIsEmailVerifiedTrueAndActiveTrue(oauth2UserResponse.email)?.let {
+            findByUserEmail(oauth2UserResponse.email)?.let {
                 throw DuplicateEmailException(getAttachedAuthProviders(it))
             }
         } else {
@@ -259,7 +260,7 @@ class UserServiceImpl(
         }
 
         checkNotNull(oauth2UserResponse.email) { "google email is null: $oauth2UserResponse" }
-        userRepository.findByEmailIgnoreCaseAndIsEmailVerifiedTrueAndActiveTrue(oauth2UserResponse.email)?.let {
+        findByUserEmail(oauth2UserResponse.email)?.let {
             throw DuplicateEmailException(getAttachedAuthProviders(it))
         }
 
@@ -282,7 +283,7 @@ class UserServiceImpl(
         }
 
         checkNotNull(oauth2UserResponse.email) { "kakao email is null: $oauth2UserResponse" }
-        userRepository.findByEmailIgnoreCaseAndIsEmailVerifiedTrueAndActiveTrue(oauth2UserResponse.email)?.let {
+        findByUserEmail(oauth2UserResponse.email)?.let {
             throw DuplicateEmailException(getAttachedAuthProviders(it))
         }
 
@@ -309,7 +310,7 @@ class UserServiceImpl(
         }
 
         checkNotNull(oauth2UserResponse.email) { "apple email is null: $oauth2UserResponse" }
-        userRepository.findByEmailIgnoreCaseAndIsEmailVerifiedTrueAndActiveTrue(oauth2UserResponse.email)?.let {
+        findByUserEmail(oauth2UserResponse.email)?.let {
             throw DuplicateEmailException(getAttachedAuthProviders(it))
         }
 
@@ -349,13 +350,14 @@ class UserServiceImpl(
         isEmailVerified: Boolean,
     ): LoginResponse {
         val credentialHash = authService.generateCredentialHash(credential)
+        val normalizedEmail = email?.let(authService::normalizeEmail)
 
         val randomNickname = userNicknameService.generateUniqueRandomNickname()
 
         val user =
             User(
-                email = email,
-                isEmailVerified = if (email != null) isEmailVerified else false,
+                email = normalizedEmail,
+                isEmailVerified = if (normalizedEmail != null) isEmailVerified else false,
                 credential = credential,
                 credentialHash = credentialHash,
                 nickname = randomNickname,
@@ -384,18 +386,16 @@ class UserServiceImpl(
         user: User,
         email: String,
     ) {
+        val normalizedEmail = authService.normalizeEmail(email)
         if (user.isEmailVerified == true) throw EmailAlreadyVerifiedException
-        if (!authService.isValidSnuMail(email)) throw InvalidEmailException
-        if (userRepository.existsByEmailIgnoreCaseAndIsEmailVerifiedTrueAndActiveTrue(
-                email,
-            )
-        ) {
+        if (!authService.isValidSnuMail(normalizedEmail)) throw InvalidEmailException
+        if (userRepository.existsByEmailAndIsEmailVerifiedTrueAndActiveTrue(normalizedEmail)) {
             throw DuplicateEmailException(getAttachedAuthProviders(user))
         }
         val key = VERIFICATION_CODE_PREFIX + user.id
         val code = (Math.random() * 1000000).toInt().toString().padStart(6, '0')
-        saveNewVerificationValue(email, code, key)
-        mailService.sendUserMail(type = UserMailType.VERIFICATION, to = email, code = code)
+        saveNewVerificationValue(normalizedEmail, code, key)
+        mailService.sendUserMail(type = UserMailType.VERIFICATION, to = normalizedEmail, code = code)
     }
 
     override suspend fun verifyEmail(
@@ -404,11 +404,17 @@ class UserServiceImpl(
     ) {
         val key = VERIFICATION_CODE_PREFIX + user.id
         val value = checkVerificationValue(key, code)
+        val normalizedEmail = authService.normalizeEmail(value.email)
         user.apply {
-            email = value.email
+            email = normalizedEmail
             isEmailVerified = true
         }
-        userRepository.save(user)
+        try {
+            userRepository.save(user)
+        } catch (e: DuplicateKeyException) {
+            val presentUser = userRepository.findByEmailAndIsEmailVerifiedTrueAndActiveTrue(normalizedEmail)
+            throw DuplicateEmailException(getAttachedAuthProviders(presentUser ?: user))
+        }
         redisTemplate.delete(key).subscribe()
     }
 
@@ -445,7 +451,7 @@ class UserServiceImpl(
         val token = socialLoginRequest.token
         val oauth2UserResponse = authService.socialLoginWithAccessToken(authProvider, token)
         if (oauth2UserResponse.email != null) {
-            val presentUser = userRepository.findByEmailIgnoreCaseAndIsEmailVerifiedTrueAndActiveTrue(oauth2UserResponse.email)
+            val presentUser = findByUserEmail(oauth2UserResponse.email)
             if (presentUser != null && presentUser.id != user.id) {
                 throw DuplicateEmailException(getAttachedAuthProviders(presentUser))
             }
@@ -572,12 +578,13 @@ class UserServiceImpl(
     }
 
     override suspend fun sendLocalIdToEmail(email: String) {
-        val users = userRepository.findAllByEmail(email).filter { it.active }
+        val normalizedEmail = authService.normalizeEmail(email)
+        val users = userRepository.findAllByEmail(normalizedEmail).filter { it.active }
         if (users.isEmpty()) throw UserNotFoundException
 
         val accountInfo = buildFindIdAccountInfo(users)
         if (accountInfo.isBlank()) throw UserNotFoundException
-        mailService.sendUserMail(type = UserMailType.FIND_ID, to = email, accountInfo = accountInfo)
+        mailService.sendUserMail(type = UserMailType.FIND_ID, to = normalizedEmail, accountInfo = accountInfo)
     }
 
     private fun buildFindIdAccountInfo(users: List<User>): String {
@@ -608,12 +615,13 @@ class UserServiceImpl(
     }
 
     override suspend fun sendResetPasswordCode(email: String) {
-        if (email.replace(emailMaskRegex, "*") == email) throw UpdateAppVersionException
-        val user = userRepository.findByEmailIgnoreCaseAndIsEmailVerifiedTrueAndActiveTrue(email) ?: throw UserNotFoundException
+        val normalizedEmail = authService.normalizeEmail(email)
+        if (normalizedEmail.replace(emailMaskRegex, "*") == normalizedEmail) throw UpdateAppVersionException
+        val user = userRepository.findByEmailAndIsEmailVerifiedTrueAndActiveTrue(normalizedEmail) ?: throw UserNotFoundException
         val key = RESET_PASSWORD_CODE_PREFIX + user.id
         val code = Base64.getUrlEncoder().encodeToString(Random.nextBytes(6))
-        saveNewVerificationValue(email, code, key)
-        mailService.sendUserMail(type = UserMailType.PASSWORD_RESET, to = email, code = code)
+        saveNewVerificationValue(normalizedEmail, code, key)
+        mailService.sendUserMail(type = UserMailType.PASSWORD_RESET, to = normalizedEmail, code = code)
     }
 
     override suspend fun verifyResetPasswordCode(
@@ -678,6 +686,9 @@ class UserServiceImpl(
         redisTemplate.opsForValue().getAndAwait(key)?.let {
             mapper.readValue<RedisVerificationValue>(it)
         }
+
+    private suspend fun findByUserEmail(email: String): User? =
+        userRepository.findByEmailAndIsEmailVerifiedTrueAndActiveTrue(authService.normalizeEmail(email))
 
     companion object {
         private val emailMaskRegex = Regex("(?<=.{3}).(?=.*@)")


### PR DESCRIPTION
## What

- 활성 상태이면서 이메일 인증이 완료된 사용자에 대해 이메일 unique index를 추가합니다.
- index와 관련 이메일 조회에 동일한 case-insensitive collation을 적용합니다.
  - `{ locale: "en", strength: 2 }`
- 이메일을 입력받는 서비스 경로에서 앞뒤 공백을 제거합니다.
- 이메일 인증 과정의 동시 요청으로 unique index 충돌이 발생하면 `DuplicateEmailException`으로 처리합니다.
- 다중 계정 아이디 찾기는 `findAllByEmail` 동작을 유지하며, case-insensitive collation만 적용합니다. 별도 lookup index는 추가하지 않습니다.

## Why

- 인증된 활성 사용자 사이에서 이메일 유일성을 DB 수준에서도 보장하기 위함입니다.
- 대소문자를 무시하는 이메일 조회가 index와 동일한 collation을 사용하도록 해, 인증 이메일 조회가 index를 정상적으로 사용할 수 있게 합니다.
- 애플리케이션의 사전 중복 확인과 실제 저장 사이의 race condition도 unique index로 막습니다.

## Index scope

다음 조건을 모두 만족하는 문서만 unique index 대상입니다.

- `active: true`
- `isEmailVerified: true`
- `email`이 string 타입

따라서 inactive 또는 미인증 계정의 동일 이메일은 허용됩니다.

## Data migration

- case-insensitive 기준으로 중복되던 인증 이메일 데이터는 정리 완료했습니다.
- collation을 사용하므로 기존 이메일을 소문자로 변환할 필요는 없습니다.
- 기존 데이터에 앞뒤 공백이 있는 경우에만 배포 전에 trim합니다.

```javascript
db.users.updateMany(
  { email: { $type: "string" } },
  [
    {
      $set: {
        email: { $trim: { input: "$email" } }
      }
    }
  ]
)
```

신규 가입, 소셜 가입, 이메일 인증 및 이메일을 입력받는 조회 경로에서는 요청 값을 trim하므로 새로 저장되는 `User.email`에는 앞뒤 공백이 들어가지 않습니다.
