### PR TITLE
아이디 찾기 이메일 조회 범위 확장

### DIFF
--- a/core/src/main/kotlin/mail/service/MailService.kt
+++ b/core/src/main/kotlin/mail/service/MailService.kt
@@ -14,6 +14,7 @@ interface MailService {
         to: String,
         code: String = "",
         localId: String = "",
+        accountInfo: String = "",
     )
 }
 
@@ -32,11 +33,12 @@ class MailServiceImpl(
         to: String,
         code: String,
         localId: String,
+        accountInfo: String,
     ) {
         if (!authService.isValidEmail(to)) {
             throw InvalidEmailException
         }
-        getUserMailContent(type, to, code, localId).let { (subject, body) ->
+        getUserMailContent(type, to, code, localId, accountInfo).let { (subject, body) ->
             mailClient.sendMail(to, subject, body)
         }
     }
@@ -46,6 +48,7 @@ class MailServiceImpl(
         email: String,
         code: String,
         localId: String,
+        accountInfo: String,
     ): MailContent {
         val mailContentList =
             mailTemplateResource.inputStream
@@ -54,6 +57,7 @@ class MailServiceImpl(
                 .replace("{code}", code)
                 .replace("{email}", email)
                 .replace("{localId}", localId)
+                .replace("{accountInfo}", accountInfo)
                 .split("\n\n")
                 .windowed(2, 2, false)
                 .map { (subject, body) -> MailContent(subject, body) }

--- a/core/src/main/kotlin/users/service/UserService.kt
+++ b/core/src/main/kotlin/users/service/UserService.kt
@@ -572,8 +572,39 @@ class UserServiceImpl(
     }
 
     override suspend fun sendLocalIdToEmail(email: String) {
-        val user = userRepository.findByEmailIgnoreCaseAndIsEmailVerifiedTrueAndActiveTrue(email) ?: throw UserNotFoundException
-        mailService.sendUserMail(type = UserMailType.FIND_ID, to = email, localId = user.credential.localId ?: throw UserNotFoundException)
+        val users = userRepository.findAllByEmail(email).filter { it.active }
+        if (users.isEmpty()) throw UserNotFoundException
+
+        val accountInfo = buildFindIdAccountInfo(users)
+        if (accountInfo.isBlank()) throw UserNotFoundException
+        mailService.sendUserMail(type = UserMailType.FIND_ID, to = email, accountInfo = accountInfo)
+    }
+
+    private fun buildFindIdAccountInfo(users: List<User>): String {
+        val localIds = users.mapNotNull { it.credential.localId }.distinct()
+        val socialProviders =
+            users
+                .flatMap { user ->
+                    listOfNotNull(
+                        user.credential.fbId?.let { "Facebook" },
+                        user.credential.googleSub?.let { "Google" },
+                        user.credential.kakaoSub?.let { "Kakao" },
+                        user.credential.appleSub?.let { "Apple" },
+                    )
+                }.distinct()
+
+        val localIdHtml =
+            if (localIds.isEmpty()) {
+                ""
+            } else {
+                "<h3>아이디</h3><ul>${localIds.joinToString(separator = "") { "<li>$it</li>" }}</ul><br/>"
+            }
+        val socialProviderHtml =
+            socialProviders.joinToString(separator = "") { provider ->
+                "<b>$provider 로그인으로 가입된 계정이 존재합니다.</b><br/>"
+            }
+
+        return localIdHtml + socialProviderHtml
     }
 
     override suspend fun sendResetPasswordCode(email: String) {

--- a/core/src/main/resources/userMailTemplate.txt
+++ b/core/src/main/resources/userMailTemplate.txt
@@ -18,5 +18,5 @@
 
 <h2>아이디 찾기 안내</h2><br/>
 안녕하세요. SNUTT입니다. <br/>
-<b>{email}로 가입된 아이디는 다음과 같습니다.</b><br/><br/>
-<h3>아이디</h3><h3>{localId}</h3><br/><br/>
+<b>{email}과 연결된 로그인 정보는 다음과 같습니다.</b><br/><br/>
+{accountInfo}<br/><br/>


### PR DESCRIPTION
## What
- 아이디 찾기에서 입력 이메일과 일치하는 활성 계정 로컬 아이디를 모두 조회하도록 변경
- 미인증 로컬 계정도 검색결과에 포함
- 소셜 로그인 계정의 경우 해당 로그인 방법을 메일에 안내
- 아이디 찾기 통합 테스트 추가

## Why
미인증 이메일 계정과 로컬 아이디가 없는 소셜 계정도 아이디 찾기 기능으로 로그인 정보를 확인할 수 있도록 하기 위함입니다.

## Notes
- 기존 어드민 이메일 검색 API(#516)와 동일하게 `User.email` 기준으로 조회합니다.
- inactive 계정은 메일 안내 대상에서 제외합니다.

## Mail Examples
<h3>아이디</h3>
<ul>
  <li>local123</li>
  <li>local456</li>
</ul>
<b>Google 소셜 로그인으로 가입된 계정이 존재합니다.</b><br/>