### PR TITLE
개인정보처리방침/이용약관 페이지에 다크모드 글씨색 지정

### DIFF
--- a/api/src/main/resources/views/privacy_policy.html
+++ b/api/src/main/resources/views/privacy_policy.html
@@ -18,6 +18,11 @@
         line-height: 1.4em;
         white-space: pre-wrap;
       }
+      @media (prefers-color-scheme: dark) {
+        body {
+          color: #eeeef3;
+        }
+      }
     </style>
   </head>
   <body>

--- a/api/src/main/resources/views/terms_of_service.html
+++ b/api/src/main/resources/views/terms_of_service.html
@@ -18,6 +18,11 @@
         line-height: 1.4em;
         white-space: pre-wrap;
       }
+      @media (prefers-color-scheme: dark) {
+        body {
+          color: #eeeef3;
+        }
+      }
     </style>
   </head>
   <body>


### PR DESCRIPTION
### 수정사항
- 개인정보처리방침/서비스이용약관 페이지 폰트 색상이 검은색으로 고정되어 있어서, 다크모드에서 잘 안보이는 문제 수정

- - -

| 변경 전 | 변경 후 |
|---|---|
| <img src="https://github.com/user-attachments/assets/5f98e015-a9b2-459f-a7c2-cbe64c2c72cf" width="300"/> | <img src="https://github.com/user-attachments/assets/5054c120-ba8f-49a2-9fa6-f51a383c4ea6" width="300"/> |