### PR TITLE
강의계획서 링크를 libproxy 대신 자체 프록시로 제공

### DIFF
--- a/api/src/main/kotlin/controller/CoursebookController.kt
+++ b/api/src/main/kotlin/controller/CoursebookController.kt
@@ -1,12 +1,13 @@
 package com.wafflestudio.snutt.controller
 
 import com.wafflestudio.snutt.common.enums.Semester
-import com.wafflestudio.snutt.common.util.SugangSnuUrlUtils.REDIRECT_PREFIX_URL
-import com.wafflestudio.snutt.common.util.SugangSnuUrlUtils.parseSyllabusUrl
+import com.wafflestudio.snutt.common.util.SugangSnuUrlUtils.SUGANG_SNU_BASE_URL
+import com.wafflestudio.snutt.common.util.SugangSnuUrlUtils.parseSyllabusPath
 import com.wafflestudio.snutt.coursebook.data.CoursebookOfficialResponse
 import com.wafflestudio.snutt.coursebook.data.CoursebookResponse
 import com.wafflestudio.snutt.coursebook.service.CoursebookService
 import com.wafflestudio.snutt.filter.SnuttNoAuthApiFilterTarget
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController
 )
 class CoursebookController(
     private val coursebookService: CoursebookService,
+    @param:Value("\${snutt.syllabus-proxy.base-url}") private val syllabusProxyBaseUrl: String,
 ) {
     @GetMapping("")
     suspend fun getCoursebooks() = coursebookService.getCoursebooks().map { CoursebookResponse(it) }
@@ -39,16 +41,16 @@ class CoursebookController(
         @RequestParam("course_number") courseNumber: String,
         @RequestParam("lecture_number") lectureNumber: String,
     ): CoursebookOfficialResponse {
-        val url =
-            parseSyllabusUrl(
+        val syllabusPath =
+            parseSyllabusPath(
                 year = year,
                 semester = semester,
                 courseNumber = courseNumber,
                 lectureNumber = lectureNumber,
             )
         return CoursebookOfficialResponse(
-            noProxyUrl = url,
-            proxyUrl = REDIRECT_PREFIX_URL + url,
+            noProxyUrl = SUGANG_SNU_BASE_URL + syllabusPath,
+            proxyUrl = syllabusProxyBaseUrl + syllabusPath,
         )
     }
 }

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -6,6 +6,8 @@ spring:
 
 snutt:
   secret-key:
+  syllabus-proxy:
+    base-url: https://snutt-proxy.wafflestudio.com
 
 springdoc:
   paths-to-match: /v1/**

--- a/core/src/main/kotlin/common/util/SugangSnuUrlUtils.kt
+++ b/core/src/main/kotlin/common/util/SugangSnuUrlUtils.kt
@@ -4,7 +4,7 @@ import com.wafflestudio.snutt.common.enums.Semester
 import org.springframework.web.util.DefaultUriBuilderFactory
 
 object SugangSnuUrlUtils {
-    const val REDIRECT_PREFIX_URL = "https://libproxy.snu.ac.kr/_Lib_Proxy_Url/"
+    const val SUGANG_SNU_BASE_URL = "https://sugang.snu.ac.kr"
 
     fun convertSemesterToSugangSnuSearchString(semester: Semester): String =
         when (semester) {
@@ -14,7 +14,7 @@ object SugangSnuUrlUtils {
             Semester.WINTER -> "U000200002U000300002"
         }
 
-    fun parseSyllabusUrl(
+    fun parseSyllabusPath(
         year: Int,
         semester: Semester,
         courseNumber: String,
@@ -22,8 +22,6 @@ object SugangSnuUrlUtils {
     ): String =
         DefaultUriBuilderFactory()
             .builder()
-            .scheme("https")
-            .host("sugang.snu.ac.kr")
             .path("/sugang/cc/cc103.action")
             .queryParam("openSchyy", year)
             .queryParam("openShtmFg", makeOpenShtmFg(semester))

--- a/core/src/testFixtures/resources/application.yaml
+++ b/core/src/testFixtures/resources/application.yaml
@@ -2,6 +2,8 @@ spring.profiles.active: test
 
 snutt:
   secret-key: test-secret-key
+  syllabus-proxy:
+    base-url: https://snutt-proxy.wafflestudio.com
 
 logging:
   level:


### PR DESCRIPTION
## 배경
sugang.snu.ac.kr 강의계획서 페이지는 Referer가 `*.snu.ac.kr`인 요청만 허용하고, 그 외에는 메인 페이지로 리다이렉트합니다. 지금까지는 libproxy를 경유시켜 이 제약을 우회하는 임시 해결책을 사용해 왔는데, 이 우회가 더 이상 동작하지 않아 프록시를 직접 운영하는 방식으로 바꿉니다. Referer 체크는 페이지뿐 아니라 탭 내용을 불러오는 ajax 엔드포인트에도 적용되고 브라우저는 Referer를 직접 설정할 수 없으므로, 서버측 프록시가 필요합니다.

## 변경사항
- Referer를 붙여 대신 요청하는 리버스 프록시 [snutt-proxy](https://github.com/wafflestudio/snutt-proxy)를 도입합니다. (배포: wafflestudio/waffle-world-oci#122)
- `GET /v1/course_books/official`의 `proxyUrl`이 libproxy 대신 `snutt-proxy.wafflestudio.com`을 가리키도록 변경합니다.
- 프록시가 수강신청 사이트와 동일한 경로 구조(`/sugang/cc/...`)를 사용하므로, 기존처럼 URL을 브라우저에서 열면 페이지의 정적 리소스와 ajax 호출까지 모두 프록시를 통해 동작합니다.
- 응답 스키마는 그대로이며 구버전 클라이언트가 사용하는 `url` 필드도 같은 값을 반환하므로 클라이언트 수정 없이 동작합니다.

## 참고
- wafflestudio/waffle-world-oci#122 머지 후에 이 PR을 머지해야 합니다. DNS 레코드는 반영되어 있습니다.