### PR TITLE
이메일 인증 중복 에러의 로그인 수단 안내 수정

### DIFF
--- a/core/src/main/kotlin/users/repository/UserRepository.kt
+++ b/core/src/main/kotlin/users/repository/UserRepository.kt
@@ -34,13 +34,6 @@ interface UserRepository : CoroutineCrudRepository<User, String> {
 
     @Query(
         value = "{ 'email': ?0, 'isEmailVerified': true, 'active': true }",
-        exists = true,
-        collation = EMAIL_CASE_INSENSITIVE_COLLATION,
-    )
-    suspend fun existsByEmailAndIsEmailVerifiedTrueAndActiveTrue(email: String): Boolean
-
-    @Query(
-        value = "{ 'email': ?0, 'isEmailVerified': true, 'active': true }",
         collation = EMAIL_CASE_INSENSITIVE_COLLATION,
     )
     suspend fun findByEmailAndIsEmailVerifiedTrueAndActiveTrue(email: String): User?

--- a/core/src/main/kotlin/users/service/UserService.kt
+++ b/core/src/main/kotlin/users/service/UserService.kt
@@ -389,8 +389,8 @@ class UserServiceImpl(
         val email = email.trim()
         if (user.isEmailVerified == true) throw EmailAlreadyVerifiedException
         if (!authService.isValidSnuMail(email)) throw InvalidEmailException
-        if (userRepository.existsByEmailAndIsEmailVerifiedTrueAndActiveTrue(email)) {
-            throw DuplicateEmailException(getAttachedAuthProviders(user))
+        userRepository.findByEmailAndIsEmailVerifiedTrueAndActiveTrue(email)?.let {
+            throw DuplicateEmailException(getAttachedAuthProviders(it))
         }
         val key = VERIFICATION_CODE_PREFIX + user.id
         val code = (Math.random() * 1000000).toInt().toString().padStart(6, '0')


### PR DESCRIPTION
## Summary
- 이메일 인증 중복 검사 시 실제 이메일 소유 계정을 조회하도록 변경
- 중복 계정의 인증 수단으로 DUPLICATE_EMAIL 안내 문구 구성
- 더 이상 사용하지 않는 exists repository 메서드 제거

## Testing
- ./gradlew spotlessCheck :api:test

## Notes
- 요청에 따라 회귀 테스트 코드는 포함하지 않음