### PR TITLE
prod 배포 알림을 Slack에서 Discord webhook으로 변경

### DIFF
--- a/.github/workflows/deploy-api-prod-native.yml
+++ b/.github/workflows/deploy-api-prod-native.yml
@@ -19,12 +19,11 @@ jobs:
     needs: deploy
     runs-on: ubuntu-latest
     steps:
-      - name: Slack Notify
-        uses: rtCamp/action-slack-notify@v2.3.3
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_CHANNEL: team-snutt-deploy
-          SLACK_TITLE: NEW RELEASE
-          SLACK_USERNAME: snutt-timetable
-          SLACK_ICON: https://user-images.githubusercontent.com/35535636/103177470-2237cb00-48be-11eb-9211-3ffa567c8ac3.png
-          SLACK_MESSAGE: Check <https://argocd.wafflestudio.com|Argo CD> for updated environment
+      - name: Discord Notify
+        uses: tsickert/discord-webhook@v6.0.0
+        with:
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
+          username: snutt-timetable
+          avatar-url: https://user-images.githubusercontent.com/35535636/103177470-2237cb00-48be-11eb-9211-3ffa567c8ac3.png
+          embed-title: NEW RELEASE
+          embed-description: Check [Argo CD](https://argocd.wafflestudio.com) for updated environment

--- a/.github/workflows/deploy-api-prod.yml
+++ b/.github/workflows/deploy-api-prod.yml
@@ -19,12 +19,11 @@ jobs:
     needs: deploy
     runs-on: ubuntu-latest
     steps:
-      - name: Slack Notify
-        uses: rtCamp/action-slack-notify@v2.3.3
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_CHANNEL: team-snutt-deploy
-          SLACK_TITLE: NEW RELEASE
-          SLACK_USERNAME: snutt-timetable
-          SLACK_ICON: https://user-images.githubusercontent.com/35535636/103177470-2237cb00-48be-11eb-9211-3ffa567c8ac3.png
-          SLACK_MESSAGE: Check <https://argocd.wafflestudio.com|Argo CD> for updated environment
+      - name: Discord Notify
+        uses: tsickert/discord-webhook@v6.0.0
+        with:
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
+          username: snutt-timetable
+          avatar-url: https://user-images.githubusercontent.com/35535636/103177470-2237cb00-48be-11eb-9211-3ffa567c8ac3.png
+          embed-title: NEW RELEASE
+          embed-description: Check [Argo CD](https://argocd.wafflestudio.com) for updated environment


### PR DESCRIPTION
prod 배포 완료 알림을 Slack에서 Discord webhook으로 변경했습니다.

## 변경 내용

`rtCamp/action-slack-notify@v2.3.3` → `tsickert/discord-webhook@v6.0.0`

기존 Slack 액션의 필드를 그대로 대응시켰습니다.

| Slack | Discord |
| --- | --- |
| `SLACK_TITLE` | `embed-title` |
| `SLACK_USERNAME` | `username` |
| `SLACK_ICON` | `avatar-url` |
| `SLACK_MESSAGE` | `embed-description` |

- Slack의 `<url|text>` 링크 마크업은 Discord 임베드가 지원하는 `[text](url)` 마크다운으로 변환했습니다.
- `SLACK_CHANNEL`은 대응 항목이 없습니다. Discord webhook은 발급 시점에 채널이 결정됩니다.
- `needs: deploy`는 그대로 두어, 이전과 동일하게 **배포 성공 시에만** 알림이 발송됩니다.

메시지 내용과 발송 조건은 기존과 동일하며, 전송 대상만 바뀝니다.

대상 워크플로는 prod 배포 2개입니다.

- `.github/workflows/deploy-api-prod.yml`
- `.github/workflows/deploy-api-prod-native.yml`

## 머지 전 필요한 작업

1. 리포지토리 시크릿에 `DISCORD_WEBHOOK` 등록 (Discord 채널 → 연동 → 웹후크에서 발급한 URL)
2. 머지 후 `SLACK_WEBHOOK` 시크릿 정리 — 이 변경 이후 코드베이스에서 더 이상 참조되지 않습니다. 다른 워크플로에서 공용으로 쓰이는 값인지만 확인 후 삭제하면 됩니다.
